### PR TITLE
Protobuf enabled endpoint for hypercube.

### DIFF
--- a/transmart-rest-api/grails-app/conf/application.groovy
+++ b/transmart-rest-api/grails-app/conf/application.groovy
@@ -54,7 +54,8 @@ grails.mime.types = [
         rss          : 'application/rss+xml',
         text         : 'text/plain',
         hal          : ['application/hal+json', 'application/hal+xml'],
-        xml          : ['text/xml', 'application/xml']
+        xml          : ['text/xml', 'application/xml'],
+        protobuf     : 'application/x-protobuf',
 ]
 
 grails.mime.use.accept.header = true

--- a/transmart-rest-api/grails-app/services/org/transmartproject/rest/MultidimensionalDataSerialisationService.groovy
+++ b/transmart-rest-api/grails-app/services/org/transmartproject/rest/MultidimensionalDataSerialisationService.groovy
@@ -8,17 +8,14 @@ import org.transmartproject.rest.protobuf.ObservationsSerializer
 class MultidimensionalDataSerialisationService {
 
     /**
-     * Serialise hypercube data to <code>out</code>.
+     * Serialises hypercube data to <code>out</code>.
      *
      * @param hypercube the hypercube to serialise.
-     * @param format the output format. Currently only 'json' is supported.
+     * @param format the output format. Supports JSON and PROTOBUF.
      * @param out the stream to serialise to.
      */
-    def writeData(HypercubeImpl hypercube, String format = "json", OutputStream out) {
-        if (!format.equalsIgnoreCase("json")) {
-            throw new UnsupportedEncodingException("Serialization format ${format} is not supported")
-        }
-        ObservationsSerializer builder = new ObservationsSerializer(hypercube)
-        builder.writeTo(out, format)
+    void serialise(HypercubeImpl hypercube, ObservationsSerializer.Format format, OutputStream out) {
+        ObservationsSerializer builder = new ObservationsSerializer(hypercube, format)
+        builder.write(out)
     }
 }

--- a/transmart-rest-api/src/test/groovy/org/transmartproject/rest/protobug/ObservationsBuilderTests.groovy
+++ b/transmart-rest-api/src/test/groovy/org/transmartproject/rest/protobug/ObservationsBuilderTests.groovy
@@ -2,12 +2,12 @@ package org.transmartproject.rest.protobug
 
 import grails.test.mixin.integration.Integration
 import grails.transaction.Rollback
+import groovy.json.JsonSlurper
 import org.junit.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.transmartproject.db.clinical.MultidimensionalDataResourceService
 import org.transmartproject.db.dataquery.clinical.ClinicalTestData
 import org.transmartproject.db.dataquery2.DimensionImpl
-import org.transmartproject.db.dataquery2.HypercubeValueImpl
 import org.transmartproject.db.dataquery2.query.Constraint
 import org.transmartproject.db.dataquery2.query.StudyConstraint
 import org.transmartproject.db.metadata.DimensionDescription
@@ -15,7 +15,7 @@ import org.transmartproject.db.TestData
 import org.transmartproject.rest.protobuf.ObservationsSerializer
 
 import static org.hamcrest.MatcherAssert.assertThat
-import static org.hamcrest.core.IsNull.notNullValue
+import static org.hamcrest.Matchers.*
 
 
 /**
@@ -33,22 +33,48 @@ class ObservationsBuilderTests {
     MultidimensionalDataResourceService queryResource
 
     @Test
-    public void testSerialization() throws Exception {
+    public void testJsonSerialization() throws Exception {
         setupData()
         Constraint constraint = new StudyConstraint(studyId: clinicalData.longitudinalStudy.studyId)
         def mockedCube = queryResource.retrieveData('clinical', [clinicalData.longitudinalStudy], constraint: constraint)
-        def builder = new ObservationsSerializer(mockedCube)
-        def blob = builder.getDimensionsDefs()
-        assertThat(blob, notNullValue())
-        Iterator<HypercubeValueImpl> it = mockedCube.iterator
-        def cellMsgs = []
-        while (it.hasNext()) {
-            HypercubeValueImpl value = it.next()
-            cellMsgs.add(builder.createCell(value))
-        }
-        assertThat(cellMsgs, notNullValue())
-        def footer = builder.getFooter()
-        assertThat(footer, notNullValue())
+        def builder = new ObservationsSerializer(mockedCube, ObservationsSerializer.Format.JSON)
+
+        def out = new ByteArrayOutputStream()
+        builder.write(out)
+        out.flush()
+        Collection result = new JsonSlurper().parse(out.toByteArray())
+
+        assertThat result.size(), is(14)
+        assertThat result, contains(
+                hasKey('dimensionDeclarations'),
+                hasKey('dimensionIndexes'),
+                hasKey('dimensionIndexes'),
+                hasKey('dimensionIndexes'),
+                hasKey('dimensionIndexes'),
+                hasKey('dimensionIndexes'),
+                hasKey('dimensionIndexes'),
+                hasKey('dimensionIndexes'),
+                hasKey('dimensionIndexes'),
+                hasKey('dimensionIndexes'),
+                hasKey('dimensionIndexes'),
+                hasKey('dimensionIndexes'),
+                hasKey('dimensionIndexes'),
+                hasKey('dimension')
+        )
+    }
+
+    @Test
+    public void testProtobufSerialization() throws Exception {
+        setupData()
+        Constraint constraint = new StudyConstraint(studyId: clinicalData.longitudinalStudy.studyId)
+        def mockedCube = queryResource.retrieveData('clinical', [clinicalData.longitudinalStudy], constraint: constraint)
+        def builder = new ObservationsSerializer(mockedCube, ObservationsSerializer.Format.PROTOBUF)
+
+        def out = new ByteArrayOutputStream()
+        builder.write(out)
+        out.flush()
+
+        assertThat out.toByteArray(), not(empty())
     }
 
     void setupData() {

--- a/transmartApp/grails-app/conf/application.groovy
+++ b/transmartApp/grails-app/conf/application.groovy
@@ -51,7 +51,8 @@ grails.mime.types = [html         : [
                      ],
                      form         : 'application/x-www-form-urlencoded',
                      multipartForm: 'multipart/form-data',
-                     jnlp         : 'application/x-java-jnlp-file'
+                     jnlp         : 'application/x-java-jnlp-file',
+                     protobuf     : 'application/x-protobuf',
 ]
 // The default codec used to encode data with ${}
 grails.views.javascript.library="jquery"


### PR DESCRIPTION
This commit should:
- enable protobuf serialisation for the `/query/hypercube` endpoint by providing a parameter `format=protobuf` or `Accept: application/x-protobuf`
- fix the JSON output of the endpoint (with `format=json` or `Accept: application/json`), by prepending `[`, writing `,` between messages and appending `]`.
Fixes [TMPDEV-105](https://jira.thehyve.nl/browse/TMPDEV-105) and [TMPDEV-103](https://jira.thehyve.nl/browse/TMPDEV-103).