### PR TITLE
V2 endpoints

### DIFF
--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/dataquery/Patient.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/dataquery/Patient.groovy
@@ -33,7 +33,7 @@ public interface Patient {
 
     /**
      * The sex of the subject. Cannot be null. If the sex is not known,
-     * {@link Sex#UNKOWN} is returned.
+     * {@link Sex#UNKNOWN} is returned.
      *
      * @return sex of the subject
      */

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/dataquery/Sex.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/dataquery/Sex.groovy
@@ -4,7 +4,7 @@ public enum Sex {
 
     MALE,
     FEMALE,
-    UNKOWN
+    UNKNOWN
 
     String toString() {
         this.name().toLowerCase(Locale.ENGLISH)
@@ -13,6 +13,6 @@ public enum Sex {
     static Sex fromString(String name) {
         Sex.values().find {
             it.toString() == name?.toLowerCase(Locale.ENGLISH)
-        } ?: UNKOWN
+        } ?: UNKNOWN
     }
 }

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/querytool/QueryResult.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/querytool/QueryResult.groovy
@@ -19,6 +19,12 @@ interface QueryResult extends ProtectedResource {
     public Long getId()
 
     /**
+     * A description of the query, set by the creator.
+     *
+     * @return the textual description of the query.
+     */
+    public String getDescription()
+    /**
      * The size of the set, or -1 if there was an error.
      *
      * @return the size of the set

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/querytool/QueryResult.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/querytool/QueryResult.groovy
@@ -24,6 +24,7 @@ interface QueryResult extends ProtectedResource {
      * @return the textual description of the query.
      */
     public String getDescription()
+
     /**
      * The size of the set, or -1 if there was an error.
      *

--- a/transmart-core-db/grails-app/conf/application.groovy
+++ b/transmart-core-db/grails-app/conf/application.groovy
@@ -23,6 +23,16 @@ hibernate {
 
 // environment specific settings
 environments {
+    test {
+        dataSource {
+            url = 'jdbc:postgresql://localhost:5433/transmart'
+            driverClassName = 'org.postgresql.Driver'
+            username = 'tm_cz'
+            password = 'tm_cz'
+            logSql = true
+            formatSql = true
+        }
+    }
     test_postgresql {
         dataSource {
             url = 'jdbc:postgresql://localhost:5432/transmart'

--- a/transmart-core-db/grails-app/conf/logback.groovy
+++ b/transmart-core-db/grails-app/conf/logback.groovy
@@ -8,11 +8,15 @@ appender('STDOUT', ConsoleAppender) {
     }
 }
 
-root(INFO, ['STDOUT'])
+if (Environment.current in [Environment.TEST, Environment.DEVELOPMENT]) {
+    root(INFO, ['STDOUT'])
+    logger('org.hibernate.type', TRACE)
+} else {
+    root(ERROR, ['STDOUT'])
+}
 
 logger('org.codehaus.groovy.grails.commons.spring', WARN)
 logger('org.codehaus.groovy.grails.domain.GrailsDomainClassCleaner', WARN)
-logger('org.hibernate.type', TRACE)
 
 def targetDir = BuildSettings.TARGET_DIR
 if (Environment.isDevelopmentMode() && targetDir) {

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/multidimquery/QueryService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/multidimquery/QueryService.groovy
@@ -17,6 +17,7 @@ import org.transmartproject.core.dataquery.highdim.projections.Projection
 import org.transmartproject.core.dataquery.highdim.projections.Projection as HDProjection
 import org.transmartproject.core.exceptions.AccessDeniedException
 import org.transmartproject.core.exceptions.InvalidRequestException
+import org.transmartproject.core.exceptions.NoSuchResourceException
 import org.transmartproject.core.multidimquery.Hypercube
 import org.transmartproject.core.ontology.ConceptsResource
 import org.transmartproject.core.querytool.QueryResult
@@ -34,6 +35,8 @@ import org.transmartproject.db.querytool.QtQueryInstance
 import org.transmartproject.db.querytool.QtQueryMaster
 import org.transmartproject.db.querytool.QtQueryResultInstance
 import org.transmartproject.db.user.User
+
+import static org.transmartproject.core.users.ProtectedOperation.WellKnownOperations.READ
 
 @Slf4j
 @Transactional
@@ -98,11 +101,11 @@ class QueryService {
             }
         } else if (constraint instanceof StudyConstraint) {
             def study = Study.findByStudyId(constraint.studyId)
-            if (!user.canPerform(ProtectedOperation.WellKnownOperations.READ, study)) {
+            if (study == null || !user.canPerform(ProtectedOperation.WellKnownOperations.READ, study)) {
                 throw new AccessDeniedException("Access denied to study: ${constraint.studyId}")
             }
         } else if (constraint instanceof StudyObjectConstraint) {
-            if (!user.canPerform(ProtectedOperation.WellKnownOperations.READ, constraint.study)) {
+            if (constraint.study == null || !user.canPerform(ProtectedOperation.WellKnownOperations.READ, constraint.study)) {
                 throw new AccessDeniedException("Access denied to study: ${constraint.study?.studyId}")
             }
         } else {
@@ -273,6 +276,17 @@ class QueryService {
         }
 
         resultInstance
+    }
+
+    QueryResult findPatientSet(Long patientSetId, User user) {
+        QueryResult queryResult = QtQueryResultInstance.findById(patientSetId)
+        if (queryResult == null) {
+            throw new NoSuchResourceException("Patient set not found with id ${patientSetId}.")
+        }
+        if (!user.canPerform(ProtectedOperation.WellKnownOperations.READ, queryResult)) {
+            throw new AccessDeniedException("Access denied to patient set with id ${patientSetId}.")
+        }
+        queryResult
     }
 
     Long patientCount(Constraint constraint, User user) {

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/accesscontrol/AccessControlChecks.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/accesscontrol/AccessControlChecks.groovy
@@ -255,7 +255,7 @@ class AccessControlChecks {
         }
 
         if (user.admin) {
-            return true
+            return org.transmartproject.db.i2b2data.Study.findByStudyId(studyIdString) != null
         }
 
         DetachedCriteria query = org.transmartproject.db.i2b2data.Study.where {

--- a/transmart-e2e/src/test/groovy/config/Config.groovy
+++ b/transmart-e2e/src/test/groovy/config/Config.groovy
@@ -13,11 +13,11 @@ class Config {
     public static final String ADMIN_USERNAME = 'admin'
     public static final String ADMIN_PASSWORD = 'admin'
 
-    public static final String PATH_HYPERCUBE = "query/hypercube"
-    public static final String PATH_AGGREGATE = "query/aggregate"
-    public static final String PATH_PATIENTS = "query/patients"
-    public static final String PATH_TREE_NODES = "v2/tree_nodes"
-    public static final String PATH_PATIENT_SET = "v2/patient_set"
+    public static final String PATH_HYPERCUBE = "/v2/observations"
+    public static final String PATH_AGGREGATE = "/v2/observations/aggregate"
+    public static final String PATH_PATIENTS = "/v2/patients"
+    public static final String PATH_TREE_NODES = "/v2/tree_nodes"
+    public static final String PATH_PATIENT_SET = "/v2/patient_sets"
     public static final String REGEXDATE = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z"
 
     //study ids

--- a/transmart-rest-api/grails-app/conf/application.groovy
+++ b/transmart-rest-api/grails-app/conf/application.groovy
@@ -137,14 +137,27 @@ hibernate {
     cache.use_query_cache = false
 }
 
-dataSource {
-    driverClassName = 'org.h2.Driver'
-    url             = "jdbc:h2:mem:testDb;MVCC=TRUE;LOCK_TIMEOUT=10000;INIT=RUNSCRIPT FROM '../transmart-core-db/h2_init.sql'"
-    username        = 'sa'
-    password        = ''
-    dbCreate        = 'update'
-    logSql          = false
-    formatSql       = true
+environments {
+    test {
+        dataSource {
+            driverClassName = 'org.h2.Driver'
+            url = "jdbc:h2:mem:testDb;MVCC=TRUE;LOCK_TIMEOUT=10000;INIT=RUNSCRIPT FROM '../transmart-core-db/h2_init.sql'"
+            username = 'sa'
+            password = ''
+            dbCreate = 'update'
+            logSql = false
+            formatSql = true
+        }
+    }
+    development {
+        dataSource {
+            url = 'jdbc:postgresql://localhost:5433/transmart'
+            driverClassName = 'org.postgresql.Driver'
+            username = 'tm_cz'
+            password = 'tm_cz'
+            logSql = true
+            formatSql = true
+        }
+    }
 }
-
 // vim: set ts=4 sw=4 et:

--- a/transmart-rest-api/grails-app/conf/logback.groovy
+++ b/transmart-rest-api/grails-app/conf/logback.groovy
@@ -8,7 +8,11 @@ appender('STDOUT', ConsoleAppender) {
     }
 }
 
-root(ERROR, ['STDOUT'])
+if (Environment.current in [Environment.TEST, Environment.DEVELOPMENT]) {
+    root(INFO, ['STDOUT'])
+} else {
+    root(ERROR, ['STDOUT'])
+}
 
 def targetDir = BuildSettings.TARGET_DIR
 if (Environment.isDevelopmentMode() && targetDir) {

--- a/transmart-rest-api/grails-app/controllers/RestApiUrlMappings.groovy
+++ b/transmart-rest-api/grails-app/controllers/RestApiUrlMappings.groovy
@@ -32,11 +32,31 @@ class RestApiUrlMappings {
         '/businessException/index'(controller: 'businessException', action: 'index')
 
         group "/v2", {
-
-            "/query/$action?"(method: 'GET', controller: 'query') {
+            "/observation_list"(method: 'GET', controller: 'query', action: 'observationList') {
                 apiVersion = 'v2'
             }
-            "/patient_set"(method: 'POST', controller: 'query', action: 'patientSet') {
+            "/observations"(method: 'GET', controller: 'query', action: 'observations') {
+                apiVersion = 'v2'
+            }
+            "/supported_fields"(method: 'GET', controller: 'query', action: 'supportedFields') {
+                apiVersion = 'v2'
+            }
+            "/observations/aggregate"(method: 'GET', controller: 'query', action: 'aggregate') {
+                apiVersion = 'v2'
+            }
+            "/observations/count"(method: 'GET', controller: 'query', action: 'count') {
+                apiVersion = 'v2'
+            }
+            "/patient_sets/$id"(method: 'GET', controller: 'patientQuery', action: 'findPatientSet') {
+                apiVersion = 'v2'
+            }
+            "/patient_sets"(method: 'POST', controller: 'patientQuery', action: 'createPatientSet') {
+                apiVersion = 'v2'
+            }
+            "/patients/$id"(method: 'GET', controller: 'patientQuery', action: 'findPatient') {
+                apiVersion = 'v2'
+            }
+            "/patients"(method: 'GET', controller: 'patientQuery', action: 'listPatients') {
                 apiVersion = 'v2'
             }
             "/tree_nodes"(method: 'GET', controller: 'tree', action: 'index') {

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/AbstractQueryController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/AbstractQueryController.groovy
@@ -1,0 +1,73 @@
+package org.transmartproject.rest
+
+import grails.artefact.Controller
+import grails.converters.JSON
+import org.grails.web.converters.exceptions.ConverterException
+import org.springframework.beans.factory.annotation.Autowired
+import org.transmartproject.core.exceptions.InvalidArgumentsException
+import org.transmartproject.core.users.UsersResource
+import org.transmartproject.db.multidimquery.QueryService
+import org.transmartproject.db.multidimquery.query.Constraint
+import org.transmartproject.db.multidimquery.query.ConstraintFactory
+import org.transmartproject.rest.misc.CurrentUser
+
+abstract class AbstractQueryController implements Controller {
+
+    @Autowired
+    QueryService queryService
+
+    @Autowired
+    CurrentUser currentUser
+
+    @Autowired
+    UsersResource usersResource
+
+    @Autowired
+    MultidimensionalDataSerialisationService multidimensionalDataSerialisationService
+
+    def conceptsResourceService
+
+    protected static Constraint parseConstraint(String constraintText) {
+        try {
+            Map constraintData = JSON.parse(constraintText) as Map
+            try {
+                return ConstraintFactory.create(constraintData)
+            } catch (Exception e) {
+                throw new InvalidArgumentsException(e.message)
+            }
+        } catch (ConverterException e) {
+            throw new InvalidArgumentsException('Cannot parse constraint parameter.')
+        }
+    }
+
+    protected Constraint getConstraint(String constraintParameterName = 'constraint') {
+        if (!params.containsKey(constraintParameterName)) {
+            throw new InvalidArgumentsException("${constraintParameterName} parameter is missing.")
+        }
+        if (!params[constraintParameterName]) {
+            throw new InvalidArgumentsException('Empty constraint parameter.')
+        }
+        String constraintParam = URLDecoder.decode(params[constraintParameterName], 'UTF-8')
+        parseConstraint(constraintParam)
+    }
+
+    protected Constraint bindConstraint() {
+        Constraint constraint = getConstraint()
+        // check for parse errors
+        if (constraint.hasErrors()) {
+            response.status = 400
+            render constraint.errors as JSON
+            return null
+        }
+        // check for validation errors
+        constraint.validate()
+        if (constraint.hasErrors()) {
+            response.status = 400
+            render constraint.errors as JSON
+            return null
+        }
+        return constraint
+    }
+
+
+}

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/ObservationController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/ObservationController.groovy
@@ -38,6 +38,7 @@ import org.transmartproject.core.ontology.Study
 import org.transmartproject.core.querytool.QueriesResource
 import org.transmartproject.core.querytool.QueryResult
 import org.transmartproject.rest.marshallers.ObservationWrapper
+import org.transmartproject.rest.marshallers.PatientWrapper
 import org.transmartproject.rest.misc.ComponentIndicatingContainer
 import org.transmartproject.rest.ontology.OntologyTermCategory
 
@@ -249,7 +250,7 @@ class ObservationController {
                             complexCellIterator.next()
 
                     return new ObservationWrapper(
-                            subject: currentRow.patient,
+                            subject: new PatientWrapper(apiVersion: 'v1', patient: currentRow.patient),
                             label: entry.key.label,
                             value: entry.value)
                 } else {
@@ -274,7 +275,7 @@ class ObservationController {
                 computeNext()
             } else {
                 new ObservationWrapper(
-                        subject: currentRow.patient,
+                        subject: new PatientWrapper(apiVersion: 'v1', patient: currentRow.patient),
                         label: currentVar.label,
                         value: value)
             }

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/PatientQueryController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/PatientQueryController.groovy
@@ -1,0 +1,152 @@
+package org.transmartproject.rest
+
+import grails.converters.JSON
+import grails.rest.Link
+import grails.web.mime.MimeType
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import org.transmartproject.core.dataquery.Patient
+import org.transmartproject.core.exceptions.InvalidArgumentsException
+import org.transmartproject.core.exceptions.InvalidRequestException
+import org.transmartproject.core.exceptions.NoSuchResourceException
+import org.transmartproject.core.ontology.OntologyTerm
+import org.transmartproject.core.querytool.QueryResult
+import org.transmartproject.db.multidimquery.query.Constraint
+import org.transmartproject.db.multidimquery.query.PatientSetConstraint
+import org.transmartproject.db.user.User
+import org.transmartproject.rest.marshallers.ContainerResponseWrapper
+import org.transmartproject.rest.marshallers.PatientWrapper
+import org.transmartproject.rest.marshallers.QueryResultWrapper
+import org.transmartproject.rest.ontology.OntologyTermCategory
+
+class PatientQueryController extends AbstractQueryController {
+
+    static responseFormats = ['json', 'hal']
+
+    /**
+     * Patients endpoint:
+     * <code>/v2/patients?constraint=${constraint}</code>
+     *
+     * Expects a {@link org.transmartproject.db.multidimquery.query.Constraint} parameter <code>constraint</code>.
+     *
+     * @return a list of {@link org.transmartproject.db.i2b2data.PatientDimension} objects for
+     * which there are observations that satisfy the constraint.
+     */
+    def listPatients(@RequestParam('api_version') String apiVersion) {
+        Constraint constraint = bindConstraint()
+        if (constraint == null) {
+            return
+        }
+        User user = (User) usersResource.getUserFromUsername(currentUser.username)
+        def patients = queryService.listPatients(constraint, user)
+        respond wrapPatients(apiVersion, patients)
+    }
+
+    /**
+     * Patients endpoint:
+     * <code>/v2/patients/${id}</code>
+     *
+     * @param id the patient id
+     *
+     * @return the {@link org.transmartproject.db.i2b2data.PatientDimension} object with id ${id}
+     * if it exists and the user has access; null otherwise.
+     */
+    def findPatient(
+            @RequestParam('api_version') String apiVersion,
+            @PathVariable('id') Long id) {
+        if (id == null) {
+            throw new InvalidArgumentsException("Parameter 'id' is missing.")
+        }
+
+        Constraint constraint = new PatientSetConstraint(patientIds: [id])
+        User user = (User) usersResource.getUserFromUsername(currentUser.username)
+        def patients = queryService.listPatients(constraint, user)
+        if (patients.empty) {
+            throw new NoSuchResourceException("Patient not found with id ${id}.")
+        }
+
+        respond new PatientWrapper(
+                patient: patients[0],
+                apiVersion: apiVersion
+        )
+    }
+
+    private def wrapPatients(String apiVersion, Collection<Patient> source) {
+        new ContainerResponseWrapper(
+                key: 'patients',
+                container: source.collect { new PatientWrapper(apiVersion: apiVersion, patient: it) },
+                componentType: Patient,
+        )
+    }
+
+    /**
+     * Patient set endpoint:
+     * <code>GET /v2/patient_sets/${id}</code>
+     *
+     * Finds the patient set ({@link org.transmartproject.core.querytool.QueryResult}) with result instance id <code>id</code>.
+     *
+     * @return a map with the query result id, size and status.
+     */
+    def findPatientSet(
+            @RequestParam('api_version') String apiVersion,
+            @PathVariable('id') Long id) {
+        User user = (User) usersResource.getUserFromUsername(currentUser.username)
+
+        QueryResult patientSet = queryService.findPatientSet(id, user)
+
+        render new QueryResultWrapper(
+                apiVersion: apiVersion,
+                queryResult: patientSet
+        ) as JSON
+    }
+
+    /**
+     * Patient set creation endpoint:
+     * <code>POST /v2/patient_sets?constraint=${constraint}&name=${name}</code>
+     *
+     * Creates a patient set ({@link org.transmartproject.core.querytool.QueryResult}) based the {@link Constraint} parameter <code>constraint</code>.
+     *
+     * @return a map with the query result id, description, size and status.
+     */
+    def createPatientSet(
+            @RequestParam('api_version') String apiVersion,
+            @RequestParam('name') String name) {
+        if (name) {
+            name = URLDecoder.decode(name, 'UTF-8').trim()
+        } else {
+            throw new InvalidArgumentsException("Parameter 'name' is missing.")
+        }
+        if (name.empty) {
+            throw new InvalidArgumentsException("Empty 'name' parameter.")
+        }
+
+        if (!request.contentType) {
+            throw new InvalidRequestException('No content type provided')
+        }
+        MimeType mimeType = new MimeType(request.contentType)
+        if (mimeType != MimeType.JSON) {
+            throw new InvalidRequestException("Content type should be " +
+                    "${MimeType.JSON.name}; got ${mimeType}.")
+        }
+        def body = request.reader.lines().iterator().join('')
+        log.info "BODY: ${body}"
+        if (body.empty) {
+            throw new InvalidRequestException('No constraint found in request body.')
+        }
+        Constraint constraint = parseConstraint(body)
+        if (constraint == null) {
+            return null
+        }
+
+        User user = (User) usersResource.getUserFromUsername(currentUser.username)
+
+        QueryResult patientSet = queryService.createPatientSet(name, constraint, user)
+
+        response.status = 201
+        render new QueryResultWrapper(
+                apiVersion: apiVersion,
+                queryResult: patientSet
+        ) as JSON
+    }
+
+}

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/PatientSetController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/PatientSetController.groovy
@@ -8,6 +8,7 @@ import org.transmartproject.core.querytool.QueriesResource
 import org.transmartproject.core.querytool.QueryDefinition
 import org.transmartproject.core.querytool.QueryDefinitionXmlConverter
 import org.transmartproject.core.querytool.QueryResult
+import org.transmartproject.rest.marshallers.QueryResultWrapper
 import org.transmartproject.rest.misc.CurrentUser
 
 import static org.transmartproject.core.users.ProtectedOperation.WellKnownOperations.BUILD_COHORT
@@ -49,7 +50,11 @@ class PatientSetController {
 
         currentUser.checkAccess(READ, queryResult)
 
-        respond queryResult
+        respond new QueryResultWrapper(
+                apiVersion: 'v1',
+                queryResult: queryResult,
+                embedPatients: true
+        )
     }
 
     /**
@@ -73,7 +78,11 @@ class PatientSetController {
 
         currentUser.checkAccess(BUILD_COHORT, queryDefinition)
 
-        respond queriesResource.runQuery(queryDefinition, currentUser.username),
-                [status: 201]
+        respond new QueryResultWrapper(
+                apiVersion: 'v1',
+                queryResult: queriesResource.runQuery(queryDefinition, currentUser.username),
+                embedPatients: true
+        ),
+        [status: 201]
     }
 }

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/QueryController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/QueryController.groovy
@@ -5,12 +5,14 @@ import grails.web.mime.MimeType
 import groovy.util.logging.Slf4j
 import org.grails.web.converters.exceptions.ConverterException
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.RequestParam
 import org.transmartproject.core.exceptions.InvalidArgumentsException
 import org.transmartproject.core.exceptions.InvalidRequestException
 import org.transmartproject.core.querytool.QueryResult
 import org.transmartproject.core.users.UsersResource
 import org.transmartproject.core.multidimquery.Hypercube
 import org.transmartproject.db.dataquery.highdim.HighDimensionResourceService
+import org.transmartproject.db.metadata.LegacyStudyException
 import org.transmartproject.db.multidimquery.HddTabularResultHypercubeAdapter
 import org.transmartproject.db.multidimquery.QueryService
 import org.transmartproject.db.multidimquery.query.*
@@ -20,79 +22,35 @@ import org.transmartproject.rest.misc.LazyOutputStreamDecorator
 import org.transmartproject.rest.protobuf.ObservationsSerializer
 
 @Slf4j
-class QueryController {
+class QueryController extends AbstractQueryController {
 
     static responseFormats = ['json', 'hal', 'protobuf']
 
-    @Autowired
-    QueryService queryService
-
-    @Autowired
-    CurrentUser currentUser
-
-    @Autowired
-    UsersResource usersResource
-
-    @Autowired
-    MultidimensionalDataSerialisationService multidimensionalDataSerialisationService
-
-    def conceptsResourceService
-
     HighDimensionResourceService highDimensionResourceService
 
-
-    private Constraint parseConstraint(String constraintText) {
-        try {
-            Map constraintData = JSON.parse(constraintText) as Map
-            try {
-                return ConstraintFactory.create(constraintData)
-            } catch (Exception e) {
-                throw new InvalidArgumentsException(e.message)
+    protected ObservationsSerializer.Format getContentFormat() {
+        ObservationsSerializer.Format format = ObservationsSerializer.Format.NONE
+        withFormat {
+            json {
+                format = ObservationsSerializer.Format.JSON
             }
-        } catch (ConverterException e) {
-            throw new InvalidArgumentsException('Cannot parse constraint parameter.')
+            protobuf {
+                format = ObservationsSerializer.Format.PROTOBUF
+            }
         }
-    }
-
-    private Constraint getConstraint(String constraintParameterName = 'constraint') {
-        if (!params.containsKey(constraintParameterName)) {
-            throw new InvalidArgumentsException("${constraintParameterName} parameter is missing.")
-        }
-        if (!params[constraintParameterName]) {
-            throw new InvalidArgumentsException('Empty constraint parameter.')
-        }
-        String constraintParam = URLDecoder.decode(params[constraintParameterName], 'UTF-8')
-        parseConstraint(constraintParam)
-    }
-
-    private Constraint bindConstraint() {
-        Constraint constraint = getConstraint()
-        // check for parse errors
-        if (constraint.hasErrors()) {
-            response.status = 400
-            render constraint.errors as JSON
-            return null
-        }
-        // check for validation errors
-        constraint.validate()
-        if (constraint.hasErrors()) {
-            response.status = 400
-            render constraint.errors as JSON
-            return null
-        }
-        return constraint
+        format
     }
 
     /**
      * Observations endpoint:
-     * <code>/query/observations?constraint=${constraint}</code>
+     * <code>/v2/observation_list?constraint=${constraint}</code>
      *
      * Expects a {@link Constraint} parameter <code>constraint</code>.
      *
      * @return a list of {@link org.transmartproject.db.i2b2data.ObservationFact} objects that
      * satisfy the constraint.
      */
-    def observations() {
+    def observationList() {
         Constraint constraint = bindConstraint()
         if (constraint == null) {
             return
@@ -104,14 +62,14 @@ class QueryController {
 
     /**
      * Hypercube endpoint:
-     * <code>/query/hypercube?constraint=${constraint}</code>
+     * <code>/v2/observations?constraint=${constraint}</code>
      *
      * Expects a {@link Constraint} parameter <code>constraint</code>.
      *
      * @return a hypercube representing the observations that satisfy the constraint.
      */
-    def hypercube() {
-        ObservationsSerializer.Format format = getContentFormat()
+    def observations() {
+        def format = contentFormat
         if (format == ObservationsSerializer.Format.NONE) {
             throw new InvalidArgumentsException("Format not supported.")
         }
@@ -121,7 +79,12 @@ class QueryController {
             return
         }
         User user = (User) usersResource.getUserFromUsername(currentUser.username)
-        Hypercube result = queryService.retrieveClinicalData(constraint, user)
+        Hypercube result
+        try {
+            result = queryService.retrieveClinicalData(constraint, user)
+        } catch(LegacyStudyException e) {
+            throw new InvalidRequestException("This endpoint does not support legacy studies.", e)
+        }
 
         log.info "Writing to format: ${format}"
         OutputStream out = new LazyOutputStreamDecorator(
@@ -138,55 +101,8 @@ class QueryController {
     }
 
     /**
-     * Patients endpoint:
-     * <code>/query/patients?constraint=${constraint}</code>
-     *
-     * Expects a {@link Constraint} parameter <code>constraint</code>.
-     *
-     * @return a list of {@link org.transmartproject.db.i2b2data.PatientDimension} objects for
-     * which there are observations that satisfy the constraint.
-     */
-    def patients() {
-        Constraint constraint = bindConstraint()
-        if (constraint == null) {
-            return
-        }
-        User user = (User) usersResource.getUserFromUsername(currentUser.username)
-        def patients = queryService.listPatients(constraint, user)
-        render patients as JSON
-    }
-
-    /**
-     * Patient set endpoint:
-     * <code>POST /v2/patient_set?constraint=${constraint}</code>
-     *
-     * Creates a patient set ({@link QueryResult}) based the {@link Constraint} parameter <code>constraint</code>.
-     *
-     * @return a map with key 'id' and the id of the resulting {@link QueryResult} as value.
-     */
-    def patientSet() {
-        if (!request.contentType) {
-            throw new InvalidRequestException('No content type provided')
-        }
-        MimeType mimeType = new MimeType(request.contentType)
-        if (mimeType != MimeType.JSON) {
-            throw new InvalidRequestException("Content type should be " +
-                    "${MimeType.JSON.name}; got ${mimeType}.")
-        }
-        Constraint constraint = parseConstraint(request.reader.lines().iterator().join(''))
-        if (constraint == null) {
-            return
-        }
-        User user = (User) usersResource.getUserFromUsername(currentUser.username)
-        QueryResult patientSet = queryService.createPatientSet("test set", constraint, user)
-        def result = [id: patientSet.id] as Map
-        response.status = 201
-        render result as JSON
-    }
-
-    /**
      * Count endpoint:
-     * <code>/query/count?constraint=${constraint}</code>
+     * <code>/v2/observations/count?constraint=${constraint}</code>
      *
      * Expects a {@link Constraint} parameter <code>constraint</code>.
      *
@@ -205,7 +121,7 @@ class QueryController {
 
     /**
      * Aggregate endpoint:
-     * <code>/query/aggregate?type=${type}&constraint=${constraint}</code>
+     * <code>/v2/observations/aggregate?type=${type}&constraint=${constraint}</code>
      *
      * Expects an {@link AggregateType} parameter <code>type</code> and {@link Constraint}
      * parameter <code>constraint</code>.
@@ -234,21 +150,18 @@ class QueryController {
         render result as JSON
     }
 
-    ObservationsSerializer.Format getContentFormat() {
-        ObservationsSerializer.Format format = ObservationsSerializer.Format.NONE
-
-        withFormat {
-            json {
-                format = ObservationsSerializer.Format.JSON
-            }
-            protobuf {
-                format = ObservationsSerializer.Format.PROTOBUF
-            }
-        }
-
-        format
-    }
-
+    /**
+     * High dimensional endpoint:
+     * <code>/v2/high_dim?assay_constraint=${assays}&biomarker_constraint=${biomarker}&projection=${projection}</code>
+     *
+     * Expects a {@link Constraint} parameter <code>assay_constraint</code> and a supported
+     * projection name (see {@link org.transmartproject.core.dataquery.highdim.projections.Projection}.
+     *
+     * The optional {@link Constraint} parameter <code>biomarker_constraint</code> allows filtering on biomarkers, e.g.,
+     * chromosomal regions and gene names.
+     *
+     * @return a hypercube representing the high dimensional data that satisfies the constraints.
+     */
     def highDim() {
         User user = (User) usersResource.getUserFromUsername(currentUser.username)
         Constraint assayConstraint = getConstraint('assay_constraint')
@@ -264,7 +177,7 @@ class QueryController {
                 biomarkerConstraint,
                 params.projection)
 
-        ObservationsSerializer.Format format = getContentFormat()
+        def format = contentFormat
         OutputStream out = new LazyOutputStreamDecorator(
                 outputStreamProducer: { ->
                     response.contentType = format.toString()
@@ -281,7 +194,7 @@ class QueryController {
 
     /**
      * Supported fields endpoint:
-     * <code>/query/supportedFields</code>
+     * <code>/v2/supportedFields</code>
      *
      * @return the list of fields supported by {@link org.transmartproject.db.multidimquery.query.FieldConstraint}.
      */

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/SubjectController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/SubjectController.groovy
@@ -100,6 +100,7 @@ class SubjectController {
     private def wrapSubjects(Collection<Patient> source, String selfLink) {
 
         new ContainerResponseWrapper(
+                key: 'subjects',
                 container: source.collect { new PatientWrapper(apiVersion: 'v1', patient: it) },
                 componentType: PatientWrapper,
                 links: [

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/SubjectController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/SubjectController.groovy
@@ -32,6 +32,7 @@ import org.transmartproject.core.exceptions.NoSuchResourceException
 import org.transmartproject.core.ontology.ConceptsResource
 import org.transmartproject.core.ontology.OntologyTerm
 import org.transmartproject.rest.marshallers.ContainerResponseWrapper
+import org.transmartproject.rest.marshallers.PatientWrapper
 import org.transmartproject.rest.ontology.OntologyTermCategory
 
 class SubjectController {
@@ -65,7 +66,7 @@ class SubjectController {
                     "does not belong to the study '$studyId'")
         }
 
-        respond patient
+        respond new PatientWrapper(apiVersion: 'v1', patient: patient)
     }
 
     /** GET request on /v1/studies/XXX/concepts/YYY/subjects
@@ -96,11 +97,11 @@ class SubjectController {
         }
     }
 
-    private def wrapSubjects(Object source, String selfLink) {
+    private def wrapSubjects(Collection<Patient> source, String selfLink) {
 
         new ContainerResponseWrapper(
-                container: source,
-                componentType: Patient,
+                container: source.collect { new PatientWrapper(apiVersion: 'v1', patient: it) },
+                componentType: PatientWrapper,
                 links: [
                         new Link(grails.rest.render.util.AbstractLinkingRenderer.RELATIONSHIP_SELF,
                                 selfLink

--- a/transmart-rest-api/grails-app/init/BootStrap.groovy
+++ b/transmart-rest-api/grails-app/init/BootStrap.groovy
@@ -22,6 +22,8 @@
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+
+import grails.util.Environment
 import groovy.util.logging.Slf4j
 import org.transmartproject.db.TestData
 import org.transmartproject.db.user.AccessLevelTestData
@@ -30,16 +32,14 @@ import org.transmartproject.db.user.AccessLevelTestData
 class BootStrap {
 
     def init = { servletContext ->
-        def testData = TestData.createDefault()
-        testData.saveAll()
-        new org.transmartproject.rest.test.TestData().createTestData()
-        AccessLevelTestData.createWithAlternativeConceptData(testData.conceptData)
-            .saveAll()
-        // FIXME: include hypercube test data
-        /*
-        def hypercubeTestData = TestData.createHypercubeDefault()
-        hypercubeTestData.saveAll()
-        */
+        if (Environment.current == Environment.TEST) {
+            log.info "Setting up test data..."
+            def testData = TestData.createDefault()
+            testData.saveAll()
+            new org.transmartproject.rest.test.TestData().createTestData()
+            AccessLevelTestData.createWithAlternativeConceptData(testData.conceptData)
+                    .saveAll()
+        }
     }
 
 }

--- a/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/ObservationsResourceTests.groovy
+++ b/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/ObservationsResourceTests.groovy
@@ -76,7 +76,7 @@ class ObservationsResourceTests extends ResourceSpec {
                 allOf(
                         hasEntry(is('subject'), allOf(
                                 hasEntry('id', subjectId),
-                                hasEntry('sex', 'UNKOWN'),
+                                hasEntry('sex', 'UNKNOWN'),
                                 hasEntry('trial', studyId),
                                 hasEntry('inTrialId', 'SUBJ_ID_1'),
                                 hasEntry('religion', null),

--- a/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/PatientSetResourceTests.groovy
+++ b/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/PatientSetResourceTests.groovy
@@ -35,6 +35,7 @@ class PatientSetResourceTests extends ResourceSpec {
         that response.json, mapWith(
                 setSize: 1,
                 status: 'FINISHED',
+                description: 'Patient set for "My query"',
                 id: isA(Number),
                 username: 'user_-301',)
         that response.json, hasSelfLink("/${VERSION}/patient_sets/${response.json['id']}")

--- a/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/QueryControllerSpec.groovy
+++ b/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/QueryControllerSpec.groovy
@@ -10,7 +10,7 @@ import org.transmartproject.rest.marshallers.MarshallerSpec
 @Slf4j
 class QueryControllerSpec extends MarshallerSpec {
 
-    public static final String VERSION = "v2"
+    public static final String VERSION = 'v2'
 
     void 'test JSON (de)serialisation'() {
         def constraint = [
@@ -27,7 +27,7 @@ class QueryControllerSpec extends MarshallerSpec {
 
         when:
         def constraintJSON = constraint.toString(false)
-        def url = "${baseURL}/$VERSION/query/observations?constraint=${URLEncoder.encode(constraintJSON, 'UTF-8')}"
+        def url = "${baseURL}/$VERSION/observation_list?constraint=${URLEncoder.encode(constraintJSON, 'UTF-8')}"
         log.info "Request URL: ${url}"
         ResponseEntity<Resource> response = getJson(url)
         String content = response.body.inputStream.readLines().join('\n')
@@ -49,7 +49,7 @@ class QueryControllerSpec extends MarshallerSpec {
         log.info "Constraint: ${constraint.toString(false)}"
 
         when:
-        def url = "${baseURL}/$VERSION/query/observations?constraint=${URLEncoder.encode(constraint.toString(false), 'UTF-8')}"
+        def url = "${baseURL}/$VERSION/observation_list?constraint=${URLEncoder.encode(constraint.toString(false), 'UTF-8')}"
         log.info "Request URL: ${url}"
 
         ResponseEntity<Resource> response = getJson(url)
@@ -70,7 +70,7 @@ class QueryControllerSpec extends MarshallerSpec {
         when:
         def constraintJSON = constraint.toString(false)[0..-2] // remove last character of the JSON string
         log.info "Invalid JSON: ${constraintJSON}"
-        def url = "${baseURL}/$VERSION/query/observations?constraint=${URLEncoder.encode(constraintJSON, 'UTF-8')}"
+        def url = "${baseURL}/$VERSION/observation_list?constraint=${URLEncoder.encode(constraintJSON, 'UTF-8')}"
         log.info "Request URL: ${url}"
 
         ResponseEntity<Resource> response = getJson(url)
@@ -84,7 +84,7 @@ class QueryControllerSpec extends MarshallerSpec {
 
     void 'test getSupportedFields'() {
         when:
-        def url = "${baseURL}/$VERSION/query/supportedFields"
+        def url = "${baseURL}/$VERSION/supported_fields"
         ResponseEntity<Resource> response = getJson(url)
 
         String content = response.body.inputStream.readLines().join('\n')
@@ -100,7 +100,5 @@ class QueryControllerSpec extends MarshallerSpec {
         response.statusCode.value() == 200
         result instanceof List
     }
-
-
 
 }

--- a/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/SubjectsResourceSpec.groovy
+++ b/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/SubjectsResourceSpec.groovy
@@ -34,7 +34,6 @@ class SubjectsResourceSpec extends ResourceSpec {
     def study = 'study_id_1'
     def defaultTrial = study.toUpperCase()
     def subjectId = -101
-    def UNKNOWN = 'UNKOWN' // funny typo here
     def concept = 'bar'
 
     def subjectsPerConceptUrl = "/${VERSION}/studies/${study}/concepts/${concept}/subjects"
@@ -167,7 +166,7 @@ class SubjectsResourceSpec extends ResourceSpec {
                        String inTrialId = 'SUBJ_ID_1') {
         allOf(
                 hasEntry('id', id),
-                hasEntry('sex', UNKNOWN),
+                hasEntry('sex', 'UNKNOWN'),
                 hasEntry('trial', trial),
                 hasEntry('inTrialId', inTrialId),
                 hasEntry('religion', null),

--- a/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/marshallers/MarshallerSpec.groovy
+++ b/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/marshallers/MarshallerSpec.groovy
@@ -38,6 +38,17 @@ class MarshallerSpec extends Specification {
     @Value('${local.server.port}')
     Integer serverPort
 
+    ResponseEntity<Resource> postJson(url, object) {
+        HttpHeaders headers = new HttpHeaders()
+        headers.set(HttpHeaders.ACCEPT, 'application/json')
+        headers.set(HttpHeaders.CONTENT_TYPE, 'application/json')
+        HttpEntity requestEntity = new HttpEntity(object, headers)
+        ResponseEntity<Resource> response = restTemplate.exchange(
+                url, HttpMethod.POST, requestEntity,
+                new ParameterizedTypeReference<Resource>() {})
+        response
+    }
+
     ResponseEntity<Resource> getJson(url) {
         HttpHeaders headers = new HttpHeaders()
         headers.set(HttpHeaders.ACCEPT, 'application/json')

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/ObservationWrapper.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/ObservationWrapper.groovy
@@ -30,7 +30,7 @@ import org.transmartproject.core.dataquery.clinical.ClinicalVariable
 
 class ObservationWrapper {
     def value
-    Patient subject
+    PatientWrapper subject
     String label
 }
 

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/PatientWrapper.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/PatientWrapper.groovy
@@ -1,0 +1,8 @@
+package org.transmartproject.rest.marshallers
+
+import org.transmartproject.core.dataquery.Patient
+
+class PatientWrapper {
+    String apiVersion
+    Patient patient
+}

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/QueryResultSerializationHelper.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/QueryResultSerializationHelper.groovy
@@ -7,28 +7,29 @@ import static grails.rest.render.util.AbstractLinkingRenderer.RELATIONSHIP_SELF
 import static org.transmartproject.rest.marshallers.MarshallerSupport.getPropertySubsetForSuperType
 
 /**
- * Serialization of {@link QueryResult} objects.
+ * Serialization of {@link QueryResultWrapper} objects.
  */
-class QueryResultSerializationHelper extends AbstractHalOrJsonSerializationHelper<QueryResult> {
+class QueryResultSerializationHelper extends AbstractHalOrJsonSerializationHelper<QueryResultWrapper> {
 
-    final Class<QueryResult> targetType = QueryResult
+    final Class<QueryResultWrapper> targetType = QueryResultWrapper
 
     @Override
-    Collection<Link> getLinks(QueryResult queryResult) {
-        [new Link(RELATIONSHIP_SELF, "/v1/patient_sets/${queryResult.id}")]
+    Collection<Link> getLinks(QueryResultWrapper object) {
+        [new Link(RELATIONSHIP_SELF, "/${object.apiVersion}/patient_sets/${object.queryResult.id}")]
     }
 
     @Override
-    Map<String, Object> convertToMap(QueryResult queryResult) {
-        def map = getPropertySubsetForSuperType(queryResult, QueryResult)
+    Map<String, Object> convertToMap(QueryResultWrapper object) {
+        def excludes = (object.embedPatients ? [] : ['patients']) as Set
+        def map = getPropertySubsetForSuperType(object.queryResult, QueryResult, excludes)
         map.status = map.status.name()
 
         map
     }
 
     @Override
-    Set<String> getEmbeddedEntities(QueryResult object) {
-        ['patients']
+    Set<String> getEmbeddedEntities(QueryResultWrapper object) {
+        object.embedPatients ? ['patients'] : []
     }
 
     final String collectionName = null /* will never be in collection */

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/QueryResultSerializationHelper.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/QueryResultSerializationHelper.groovy
@@ -20,9 +20,13 @@ class QueryResultSerializationHelper extends AbstractHalOrJsonSerializationHelpe
 
     @Override
     Map<String, Object> convertToMap(QueryResultWrapper object) {
-        def excludes = (object.embedPatients ? [] : ['patients']) as Set
-        def map = getPropertySubsetForSuperType(object.queryResult, QueryResult, excludes)
+        def map = getPropertySubsetForSuperType(object.queryResult, QueryResult, ['patients'] as Set)
         map.status = map.status.name()
+        if (object.embedPatients) {
+            map.patients = object.queryResult.patients.collect {
+                new PatientWrapper(apiVersion: object.apiVersion, patient: it)
+            }
+        }
 
         map
     }

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/QueryResultWrapper.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/QueryResultWrapper.groovy
@@ -1,0 +1,9 @@
+package org.transmartproject.rest.marshallers
+
+import org.transmartproject.core.querytool.QueryResult
+
+class QueryResultWrapper {
+    String apiVersion
+    QueryResult queryResult
+    boolean embedPatients = false
+}

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/misc/CurrentUser.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/misc/CurrentUser.groovy
@@ -2,6 +2,7 @@ package org.transmartproject.rest.misc
 
 import grails.plugin.springsecurity.SpringSecurityService
 import grails.plugin.springsecurity.SpringSecurityUtils
+import grails.util.Environment
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Scope
@@ -33,7 +34,12 @@ class CurrentUser implements User {
                 !SpringSecurityUtils.securityConfig.active) {
             log.warn "Spring security service not available or inactive, " +
                     "returning dummy user administrator"
-            return new DummyAdministrator()
+            if (Environment.current == Environment.DEVELOPMENT) {
+                return new DummyDevAdministrator()
+            } else if (Environment.current == Environment.TEST) {
+                return new DummyTestAdministrator()
+            }
+            return null
         }
 
         if (!springSecurityService.isLoggedIn()) {
@@ -78,7 +84,7 @@ class CurrentUser implements User {
         "CurrentUser(${delegate.toString()})"
     }
 
-    static class DummyAdministrator implements User {
+    static class DummyTestAdministrator implements User {
 
         /* These correspond to the properties of the default transmart
          * administrator user */
@@ -91,4 +97,19 @@ class CurrentUser implements User {
             true
         }
     }
+
+    static class DummyDevAdministrator implements User {
+
+        /* These correspond to the properties of the default transmart
+         * administrator user */
+        final Long id = 1
+        final String username = 'admin'
+        final String realName = 'Sys Admin'
+
+        @Override
+        boolean canPerform(ProtectedOperation operation, ProtectedResource protectedResource) {
+            true
+        }
+    }
+
 }

--- a/transmart-rest-api/src/test/groovy/org/transmartproject/rest/protobug/ObservationsBuilderTests.groovy
+++ b/transmart-rest-api/src/test/groovy/org/transmartproject/rest/protobug/ObservationsBuilderTests.groovy
@@ -74,7 +74,6 @@ class ObservationsBuilderTests extends Specification {
         builder.write(s_out)
         s_out.flush()
         def data = s_out.toByteArray()
-        log.info "OUTPUT: ${s_out.toString()}"
 
         then:
         data != null

--- a/transmartApp/grails-app/controllers/UrlMappings.groovy
+++ b/transmartApp/grails-app/controllers/UrlMappings.groovy
@@ -11,10 +11,17 @@ class UrlMappings {
         "/"(controller: 'userLanding', action: 'index')
         "500"(view: '/error')
 
+        group("/v2") {
+            "/oauth/verify"(controller: 'oauth', action: 'verify')
+            "/oauth/authorize"(uri: "/oauth/authorize.dispatch")
+            "/oauth/token"(uri: "/oauth/token.dispatch")
+        }
+
         group("/v1") {
             "/oauth/verify"(controller: 'oauth', action: 'verify')
             "/oauth/authorize"(uri: "/oauth/authorize.dispatch")
             "/oauth/token"(uri: "/oauth/token.dispatch")
         }
+
     }
 }


### PR DESCRIPTION
- Fix `UNKOWN` typo
- Reorganise `/v2` endpoints: `GET /v2/observations` gets the hypercube, `POST /v2/patient_sets` creates a patient set, etc.
- Fix some HAL serialisation issues with versioned API (include valid links).