### PR TITLE
refactor VisitDimension

### DIFF
--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/multidimquery/DimensionImpl.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/multidimquery/DimensionImpl.groovy
@@ -1,9 +1,10 @@
 package org.transmartproject.db.multidimquery
 
 import com.google.common.collect.ImmutableMap
-import grails.util.Pair
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.Immutable
 import groovy.transform.InheritConstructors
 import groovy.transform.TupleConstructor
 import org.apache.commons.lang.NotImplementedException
@@ -507,8 +508,8 @@ class LocationDimension extends I2b2Dimension<String,String> implements Serializ
 }
 
 @CompileStatic @InheritConstructors
-class VisitDimension extends DimensionImpl<I2b2VisitDimension, Pair<BigDecimal,Long>> implements
-        CompositeElemDim<I2b2VisitDimension, Pair<BigDecimal,Long>> {
+class VisitDimension extends DimensionImpl<I2b2VisitDimension, VisitKey> implements
+        CompositeElemDim<I2b2VisitDimension, VisitKey> {
     Class elemType = I2b2VisitDimension
     List elemFields = ["patientInTrialId", "encounterNum", "activeStatusCd", "startDate", "endDate", "inoutCd",
                                       "locationCd"]
@@ -527,23 +528,37 @@ class VisitDimension extends DimensionImpl<I2b2VisitDimension, Pair<BigDecimal,L
 
     static private BigDecimal minusOne = new BigDecimal(-1)
 
-    @Override Pair<BigDecimal,Long> getElementKey(Map result) {
+    @Override VisitKey getElementKey(Map result) {
         BigDecimal encounterNum = (BigDecimal) getKey(result, alias)
-        encounterNum == minusOne ? null : new Pair(encounterNum, result.patientId)
+        encounterNum == minusOne ? null : new VisitKey(encounterNum, (Long) result.patientId)
     }
 
     @CompileDynamic
-    @Override List<I2b2VisitDimension> doResolveElements(List<Pair<BigDecimal,Long>> elementKeys) {
+    @Override List<I2b2VisitDimension> doResolveElements(List<VisitKey> elementKeys) {
         (List) I2b2VisitDimension.withCriteria {
             or {
-                elementKeys.each { Pair key ->
+                elementKeys.each { VisitKey key ->
                     and {
-                        eq 'encounterNum', key.aValue
-                        eq 'patient.id', key.bValue
+                        eq 'encounterNum', key.encounterNum
+                        eq 'patient.id', key.patientId
                     }
                 }
             }
         }
+    }
+
+    // The same as @Immutable, but @Immutable generates some rather dynamic/inefficient constructors and a toString()
+    // I don't quite like
+    @EqualsAndHashCode
+    static private class VisitKey {
+        final BigDecimal encounterNum
+        final Long patientId
+
+        VisitKey(BigDecimal encounterNum, Long patientId) {
+            this.encounterNum = encounterNum; this.patientId = patientId
+        }
+
+        String toString() { "VisitKey(encounterNum: $encounterNum, patientId: $patientId)" }
     }
 }
 


### PR DESCRIPTION
Use a VisitKey class instead of a generic Pair, to improve debuggability in the case of database errors