### PR TITLE
Some minor refactorings

### DIFF
--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/dataquery/clinical/AcrossTrialsDataQuery.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/dataquery/clinical/AcrossTrialsDataQuery.groovy
@@ -77,7 +77,7 @@ class AcrossTrialsDataQuery {
             def hibDetachedCriteria = HibernateCriteriaBuilder.getHibernateDetachedCriteria(null, patients.forIds())
             criteriaBuilder.add(Subqueries.propertyIn('patient.id', hibDetachedCriteria))
         } else {
-            InQuery.addIn(criteriaBuilder, 'patient', patients as List)
+            InQuery.addIn(criteriaBuilder, 'patient', patients)
         }
 
         InQuery.addIn(criteriaBuilder, 'modifierCd', clinicalVariables*.code).scroll ScrollMode.FORWARD_ONLY
@@ -113,7 +113,7 @@ class AcrossTrialsDataQuery {
                 property 'code'
             }
         }
-        def res = InQuery.addIn(builder, 'path', conceptPaths.keySet() as List).list()
+        def res = InQuery.addIn(builder, 'path', conceptPaths.keySet()).list()
 
         for (modifier in res) {
             String path = modifier[0],

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/dataquery/highdim/dataconstraints/PropertyDataConstraint.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/dataquery/highdim/dataconstraints/PropertyDataConstraint.groovy
@@ -34,7 +34,7 @@ class PropertyDataConstraint implements CriteriaDataConstraint {
         criteria.with {
             if (values instanceof Collection) {
                 if (!values.isEmpty()) {
-                    InQuery.addIn(criteria, property, values as List)
+                    InQuery.addIn(criteria, property, values)
                 } else {
                     criteria.addToCriteria(Restrictions.sqlRestriction(
                             "'empty_in_criteria_for_$property' = ''"))

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/multidimquery/DimensionImpl.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/multidimquery/DimensionImpl.groovy
@@ -179,7 +179,7 @@ abstract class DimensionImpl<ELT,ELKey> implements Dimension {
     }
 
     static List<ELT> resolveWithInQuery(BuildableCriteria criteria, List<ELKey> elementKeys, String property = 'id') {
-        List res = ((Criteria)InQuery.addIn(criteria as HibernateCriteriaBuilder, property, elementKeys)).list()
+        List res = InQuery.addIn(criteria as HibernateCriteriaBuilder, property, elementKeys).list()
         sort(res, elementKeys, property)
         res
     }


### PR DESCRIPTION
InQuery.addIn accepts Iterable instead of List. Saves some unnecessary to-list conversions

Also retrieve bean by type instead of name.
Don't create a disjunction if there are less than 1000 items.