### PR TITLE
Force grid view clear when adding a concept to comparison.

### DIFF
--- a/transmartApp/grails-app/assets/javascripts/datasetExplorer/i2b2common.js
+++ b/transmartApp/grails-app/assets/javascripts/datasetExplorer/i2b2common.js
@@ -304,7 +304,8 @@ function resetSelected()
 	selectedConcept = null
 	jQuery(".panelBoxListItem").each(function (){
 		jQuery(this).removeClass("selected")
-	})
+	});
+	clearGrid();
 }
 
 function conceptClick(event)
@@ -320,7 +321,7 @@ function selectConcept(concept)
 		if (arguments && arguments.length > 1 && !arguments[1])
 			return;
 	}
-	resetSelected()
+	resetSelected();
 	selectedConcept=concept; //select this one
 	selectedDiv=concept.parentNode;
 	selectedConcept.className=selectedConcept.className+" selected";


### PR DESCRIPTION
Fixes [TMPDEV-289](https://jira.thehyve.nl/browse/TMPDEV-289), [TMPUAT-75](https://jira.thehyve.nl/browse/TMPUAT-75).
Note that this bug is also present in other tranSMART versions. Can be reproduced on `test-1dot2` as well.