### PR TITLE
E2e requires study

### DIFF
--- a/transmart-rest-api-e2e/src/test/groovy/annotations/RequiresStudy.java
+++ b/transmart-rest-api-e2e/src/test/groovy/annotations/RequiresStudy.java
@@ -1,0 +1,15 @@
+package annotations;
+
+import org.spockframework.runtime.extension.ExtensionAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtensionAnnotation(RequiresStudyExtension.class)
+public @interface RequiresStudy {
+    String[] value();
+}

--- a/transmart-rest-api-e2e/src/test/groovy/annotations/RequiresStudyExtension.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/annotations/RequiresStudyExtension.groovy
@@ -51,7 +51,6 @@ class RequiresStudyExtension extends AbstractAnnotationDrivenExtension<RequiresS
                 throw new ExtensionException("Failed to retrieve loadedStudies for @RequiresStudy", e);
             }
         }
-        println("@RequiresStudy check")
         return loadedStudies.containsAll(studies)
     }
 }

--- a/transmart-rest-api-e2e/src/test/groovy/annotations/RequiresStudyExtension.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/annotations/RequiresStudyExtension.groovy
@@ -1,0 +1,57 @@
+package annotations
+
+import base.ContentTypeFor
+import groovyx.net.http.HTTPBuilder
+import org.spockframework.runtime.GroovyRuntimeUtil
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.extension.ExtensionException
+import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.ISkippable
+import org.spockframework.runtime.model.SpecInfo
+
+import static base.RestHelper.*
+import static config.Config.*
+
+class RequiresStudyExtension extends AbstractAnnotationDrivenExtension<RequiresStudy> {
+
+    private static Set<String> loadedStudies = new HashSet<String>()
+
+    @Override
+    void visitSpecAnnotation(RequiresStudy annotation, SpecInfo spec) {
+        doVisit(annotation, spec)
+    }
+
+    @Override
+    void visitFeatureAnnotation(RequiresStudy annotation, FeatureInfo feature) {
+        doVisit(annotation, feature)
+    }
+
+    private void doVisit(RequiresStudy annotation, ISkippable skippable) {
+        Object result = studiesLoaded(annotation.value())
+
+        if (!GroovyRuntimeUtil.isTruthy(result)) {
+            skippable.setSkipped(true)
+        }
+    }
+
+    private studiesLoaded(String... studies){
+        if (loadedStudies?.empty) {
+            try {
+                println("retrieving loaded studies")
+                def http = new HTTPBuilder(BASE_URL)
+                def token = oauth2Authenticate(http, [username: ADMIN_USERNAME, password: ADMIN_PASSWORD])[1]
+
+                def v1studies = get(http, [path: V1_PATH_STUDIES, acceptType: ContentTypeFor.JSON, accessToken: token]).studies as List
+                loadedStudies.addAll(v1studies*.id as Set)
+
+                def v2studies = get(http, [path: PATH_STUDIES, acceptType: ContentTypeFor.JSON, accessToken: token]).studies as List
+                loadedStudies.addAll(v2studies*.studyId as Set)
+                println("studies retrieved. loadedStudies: ${loadedStudies}")
+            } catch (Exception e) {
+                throw new ExtensionException("Failed to retrieve loadedStudies for @RequiresStudy", e);
+            }
+        }
+        println("@RequiresStudy check")
+        return loadedStudies.containsAll(studies)
+    }
+}

--- a/transmart-rest-api-e2e/src/test/groovy/annotations/RequiresStudyExtension.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/annotations/RequiresStudyExtension.groovy
@@ -1,6 +1,5 @@
 package annotations
 
-import base.ContentTypeFor
 import groovyx.net.http.HTTPBuilder
 import org.spockframework.runtime.GroovyRuntimeUtil
 import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
@@ -9,7 +8,9 @@ import org.spockframework.runtime.model.FeatureInfo
 import org.spockframework.runtime.model.ISkippable
 import org.spockframework.runtime.model.SpecInfo
 
-import static base.RestHelper.*
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.RestHelper.get
+import static base.RestHelper.oauth2Authenticate
 import static config.Config.*
 
 class RequiresStudyExtension extends AbstractAnnotationDrivenExtension<RequiresStudy> {
@@ -34,17 +35,17 @@ class RequiresStudyExtension extends AbstractAnnotationDrivenExtension<RequiresS
         }
     }
 
-    private studiesLoaded(String... studies){
+    private studiesLoaded(String... studies) {
         if (loadedStudies?.empty) {
             try {
-                println("retrieving loaded studies")
+                println("retrieving studies loaded on ${BASE_URL}")
                 def http = new HTTPBuilder(BASE_URL)
                 def token = oauth2Authenticate(http, [username: ADMIN_USERNAME, password: ADMIN_PASSWORD])[1]
 
-                def v1studies = get(http, [path: V1_PATH_STUDIES, acceptType: ContentTypeFor.JSON, accessToken: token]).studies as List
+                def v1studies = get(http, [path: V1_PATH_STUDIES, acceptType: contentTypeForJSON, accessToken: token]).studies as List
                 loadedStudies.addAll(v1studies*.id as Set)
 
-                def v2studies = get(http, [path: PATH_STUDIES, acceptType: ContentTypeFor.JSON, accessToken: token]).studies as List
+                def v2studies = get(http, [path: PATH_STUDIES, acceptType: contentTypeForJSON, accessToken: token]).studies as List
                 loadedStudies.addAll(v2studies*.studyId as Set)
                 println("studies retrieved. loadedStudies: ${loadedStudies}")
             } catch (Exception e) {

--- a/transmart-rest-api-e2e/src/test/groovy/base/ContentTypeFor.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/base/ContentTypeFor.groovy
@@ -4,9 +4,9 @@ package base
  * Created by barteldklasens on 2/17/17.
  */
 public interface ContentTypeFor {
-    String HAL = 'application/hal+json',
-            XML = 'application/xml',
-            octetStream = 'application/octet-stream',
-            Protobuf = 'application/x-protobuf',
-            JSON = 'application/json'
+    String contentTypeForHAL = 'application/hal+json',
+            contentTypeForXML = 'application/xml',
+            contentTypeForoctetStream = 'application/octet-stream',
+            contentTypeForProtobuf = 'application/x-protobuf',
+            contentTypeForJSON = 'application/json'
 }

--- a/transmart-rest-api-e2e/src/test/groovy/base/ContentTypeFor.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/base/ContentTypeFor.groovy
@@ -1,0 +1,12 @@
+package base
+
+/**
+ * Created by barteldklasens on 2/17/17.
+ */
+public interface ContentTypeFor {
+    String HAL = 'application/hal+json',
+            XML = 'application/xml',
+            octetStream = 'application/octet-stream',
+            Protobuf = 'application/x-protobuf',
+            JSON = 'application/json'
+}

--- a/transmart-rest-api-e2e/src/test/groovy/base/RESTSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/base/RESTSpec.groovy
@@ -2,16 +2,11 @@
 package base
 
 import groovy.json.JsonBuilder
-import groovyx.net.http.ContentType
 import groovyx.net.http.HTTPBuilder
-import groovyx.net.http.Method
-import groovyx.net.http.URIBuilder
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers
 import selectors.ObservationSelector
 import selectors.ObservationSelectorJson
-import selectors.ObservationsMessageProto
-import org.transmartproject.rest.hypercubeProto.ObservationsProto
 import selectors.ObservationsMessageJson
 import spock.lang.Shared
 import spock.lang.Specification
@@ -22,12 +17,6 @@ import static config.Config.*
 import static org.hamcrest.Matchers.*
 
 abstract class RESTSpec extends Specification{
-
-    def static contentTypeForHAL = 'application/hal+json'
-    def static contentTypeForJSON = 'application/json'
-    def static contentTypeForProtobuf = 'application/x-protobuf'
-    def static contentTypeForoctetStream = 'application/octet-stream'
-    def static contentTypeForXML = 'application/xml'
 
     private static HashMap<String, String> oauth2token = [:]
 
@@ -45,157 +34,39 @@ abstract class RESTSpec extends Specification{
                 'password' : password]
     }
 
-    def oauth2Authenticate(userCredentials){
-        def json = post([
-                path: 'oauth/token',
-                acceptType: contentTypeForJSON,
-                query: ['grant_type': 'password', 'client_id': 'glowingbear-js', 'client_secret': '', 'username': userCredentials.'username', 'password': userCredentials.'password'],
-                skipOauth: true
-        ])
-
-        if (DEBUG){
-            println "Authenticate: username=${userCredentials.'username'} password=${userCredentials.'password'} token=${json.access_token}"
-        }
-
-        oauth2token.put(userCredentials.username, json.access_token)
-    }
-
     def getToken(User = user){
         if (oauth2token.get(user.'username') == null){
-            oauth2Authenticate(user)
+            oauth2token.put(RestHelper.oauth2Authenticate(http, user))
         }
         return oauth2token.get(user.'username')
     }
 
     def delete(def requestMap){
-        http.request(Method.DELETE) { req ->
-            uri.path = requestMap.path
-            uri.query = requestMap.query
-            if (!requestMap.skipOauth && OAUTH_NEEDED){
-                headers.'Authorization' = 'Bearer ' + getToken()
-            }
-
-            println(uri.toString())
-            response.success = { resp, reader ->
-                println resp.statusLine.statusCode
-                println resp.headers.'Content-Type'
-                assert resp.statusLine.statusCode == requestMap.statusCode ?: 200
-                def result
-                result = reader
-                if (DEBUG) { println result }
-                return result
-            }
-
-            response.failure = { resp, reader ->
-                assert resp.statusLine.statusCode == requestMap.statusCode : "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
-                def result = reader
-                if (DEBUG){ println result }
-                return result
-            }
+        if (!requestMap.skipOauth && OAUTH_NEEDED){
+            requestMap.'accessToken' = getToken()
         }
+        RestHelper.delete(http, requestMap)
     }
 
     def put(def requestMap){
-        http.request(Method.PUT, ContentType.JSON) { req ->
-            uri.path = requestMap.path
-            uri.query = requestMap.query
-            headers.Accept = requestMap.acceptType
-            body = requestMap.body
-            if (!requestMap.skipOauth && OAUTH_NEEDED){
-                headers.'Authorization' = 'Bearer ' + getToken()
-            }
-
-            println(uri.toString())
-            response.success = { resp, reader ->
-                println resp.statusLine.statusCode
-                println resp.headers.'Content-Type'
-                assert resp.statusLine.statusCode == requestMap.statusCode ?: 200
-                def result = reader
-                if (DEBUG) { println result }
-                return result
-            }
-
-            response.failure = { resp, reader ->
-                assert resp.statusLine.statusCode == requestMap.statusCode : "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
-                def result = reader
-                if (DEBUG){ println result }
-                return result
-            }
+        if (!requestMap.skipOauth && OAUTH_NEEDED){
+            requestMap.'accessToken' = getToken()
         }
+        RestHelper.put(http, requestMap)
     }
 
     def post(def requestMap){
-        http.request(Method.POST, ContentType.JSON) { req ->
-            uri.path = requestMap.path
-            uri.query = requestMap.query
-            headers.Accept = requestMap.acceptType
-            headers.'Content-Type' = requestMap.contentType
-            body = requestMap.body
-            if (!requestMap.skipOauth && OAUTH_NEEDED){
-                headers.'Authorization' = 'Bearer ' + getToken()
-            }
-
-            println(uri.toString())
-            response.success = { resp, reader ->
-                println resp.statusLine.statusCode
-                println resp.headers.'Content-Type'
-                assert resp.statusLine.statusCode == requestMap.statusCode ?: 200
-                def result = reader
-                if (DEBUG) { println result }
-                return result
-            }
-
-            response.failure = { resp, reader ->
-                assert resp.statusLine.statusCode == requestMap.statusCode : "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
-                def result = reader
-                if (DEBUG){ println result }
-                return result
-            }
+        if (!requestMap.skipOauth && OAUTH_NEEDED){
+            requestMap.'accessToken' = getToken()
         }
+        RestHelper.post(http, requestMap)
     }
 
     def get(def requestMap){
-        http.request(Method.GET) { req ->
-            if(requestMap.path == PATH_OBSERVATIONS && !requestMap.query.type) {
-                requestMap.query.type = 'clinical'
-            }
-
-            uri.path = requestMap.path
-            uri.query = requestMap.query
-            headers.Accept = requestMap.acceptType
-            if (!requestMap.skipOauth && OAUTH_NEEDED){
-                headers.'Authorization' = 'Bearer ' + getToken()
-            }
-
-
-            println(uri.toString())
-            response.success = { resp, reader ->
-                println resp.statusLine.statusCode
-                println resp.headers.'Content-Type'
-                assert resp.statusLine.statusCode == requestMap.statusCode ?: 200
-                assert resp.headers.'Content-Type'.contains(requestMap.acceptType) : "response was successful but not what was expected. if type = html: either login failed or the endpoint is not in your application.groovy file"
-                def result
-                switch (requestMap.acceptType){
-                    case contentTypeForProtobuf:
-                        result = parseProto(resp.entity.content)
-                        break
-                    case contentTypeForJSON:
-                        result = reader
-                        break
-                    default:
-                        result = reader
-                }
-                if (DEBUG) { println result }
-                return result
-            }
-
-            response.failure = { resp, reader ->
-                assert resp.statusLine.statusCode == requestMap.statusCode : "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
-                def result = reader
-                if (DEBUG){ println result }
-                return result
-            }
+        if (!requestMap.skipOauth && OAUTH_NEEDED){
+            requestMap.'accessToken' = getToken()
         }
+        RestHelper.get(http, requestMap)
     }
 
     static def jsonSelector = {new ObservationSelectorJson(parseHypercube(it))}
@@ -225,32 +96,6 @@ abstract class RESTSpec extends Specification{
         def cells = jsonHypercube.cells
         def dimensionElements = jsonHypercube.dimensionElements
         return new ObservationsMessageJson(dimensionDeclarations, cells, dimensionElements)
-    }
-
-    static def parseProto(s_in){
-        def header = ObservationsProto.Header.parseDelimitedFrom(s_in)
-        if(header.error) throw new RuntimeException("Error in protobuf header message: "+header.error)
-        if (header.dimensionDeclarationsCount == 0){
-            return new ObservationsMessageProto()
-        }
-        if (DEBUG){println('proto header = ' + header)}
-        boolean last = header.last
-        def cells = []
-        int count = 0
-        while(!last) {
-            count++
-            def cell = ObservationsProto.Cell.parseDelimitedFrom(s_in)
-            assert cell != null, "null cell found"
-            if(cell.error) throw new RuntimeException("Error in protobuf cell message: "+cell.error)
-            last = cell.last
-            cells << cell
-        }
-        if (DEBUG){println('proto cells = ' + cells)}
-        def footer = ObservationsProto.Footer.parseDelimitedFrom(s_in)
-        if(footer.error) throw new RuntimeException("Error in protobuf footer message: "+footer.error)
-        if (DEBUG){println('proto footer = ' + footer)}
-
-        return new ObservationsMessageProto(header, cells, footer)
     }
 
     /**

--- a/transmart-rest-api-e2e/src/test/groovy/base/RestHelper.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/base/RestHelper.groovy
@@ -135,10 +135,10 @@ class RestHelper {
                 assert resp.headers.'Content-Type'.contains(requestMap.acceptType) : "response was successful but not what was expected. if type = html: either login failed or the endpoint is not in your application.groovy file"
                 def result
                 switch (requestMap.acceptType){
-                    case contentTypeForProtobuf:
+                    case ContentTypeFor.Protobuf:
                         result = parseProto(resp.entity.content)
                         break
-                    case contentTypeForJSON:
+                    case ContentTypeFor.JSON:
                         result = reader
                         break
                     default:

--- a/transmart-rest-api-e2e/src/test/groovy/base/RestHelper.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/base/RestHelper.groovy
@@ -6,31 +6,33 @@ import groovyx.net.http.Method
 import org.transmartproject.rest.hypercubeProto.ObservationsProto
 import selectors.ObservationsMessageProto
 
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
 import static config.Config.DEBUG
 import static config.Config.PATH_OBSERVATIONS
 
 class RestHelper {
 
-    static oauth2Authenticate(HTTPBuilder http, userCredentials){
+    static oauth2Authenticate(HTTPBuilder http, userCredentials) {
         def json = post(http, [
-                path: 'oauth/token',
-                acceptType: ContentTypeFor.JSON,
-                query: ['grant_type': 'password', 'client_id': 'glowingbear-js', 'client_secret': '', 'username': userCredentials.'username', 'password': userCredentials.'password'],
-                skipOauth: true
+                path      : 'oauth/token',
+                acceptType: contentTypeForJSON,
+                query     : ['grant_type': 'password', 'client_id': 'glowingbear-js', 'client_secret': '', 'username': userCredentials.'username', 'password': userCredentials.'password'],
+                skipOauth : true
         ])
 
-        if (DEBUG){
+        if (DEBUG) {
             println "Authenticate: username=${userCredentials.'username'} password=${userCredentials.'password'} token=${json.access_token}"
         }
 
         [userCredentials.username, json.access_token]
     }
 
-    static delete(HTTPBuilder http, Map requestMap){
+    static delete(HTTPBuilder http, Map requestMap) {
         http.request(Method.DELETE) { req ->
             uri.path = requestMap.path
             uri.query = requestMap.query
-            if (requestMap.accessToken){
+            if (requestMap.accessToken) {
                 headers.'Authorization' = 'Bearer ' + requestMap.accessToken
             }
 
@@ -41,26 +43,30 @@ class RestHelper {
                 assert resp.statusLine.statusCode == requestMap.statusCode ?: 200
                 def result
                 result = reader
-                if (DEBUG) { println result }
+                if (DEBUG) {
+                    println result
+                }
                 return result
             }
 
             response.failure = { resp, reader ->
-                assert resp.statusLine.statusCode == requestMap.statusCode : "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
+                assert resp.statusLine.statusCode == requestMap.statusCode: "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
                 def result = reader
-                if (DEBUG){ println result }
+                if (DEBUG) {
+                    println result
+                }
                 return result
             }
         }
     }
 
-    static put(HTTPBuilder http, Map requestMap){
+    static put(HTTPBuilder http, Map requestMap) {
         http.request(Method.PUT, ContentType.JSON) { req ->
             uri.path = requestMap.path
             uri.query = requestMap.query
             headers.Accept = requestMap.acceptType
             body = requestMap.body
-            if (requestMap.accessToken){
+            if (requestMap.accessToken) {
                 headers.'Authorization' = 'Bearer ' + requestMap.accessToken
             }
 
@@ -70,27 +76,31 @@ class RestHelper {
                 println resp.headers.'Content-Type'
                 assert resp.statusLine.statusCode == requestMap.statusCode ?: 200
                 def result = reader
-                if (DEBUG) { println result }
+                if (DEBUG) {
+                    println result
+                }
                 return result
             }
 
             response.failure = { resp, reader ->
-                assert resp.statusLine.statusCode == requestMap.statusCode : "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
+                assert resp.statusLine.statusCode == requestMap.statusCode: "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
                 def result = reader
-                if (DEBUG){ println result }
+                if (DEBUG) {
+                    println result
+                }
                 return result
             }
         }
     }
 
-    static post(HTTPBuilder http, Map requestMap){
+    static post(HTTPBuilder http, Map requestMap) {
         http.request(Method.POST, ContentType.JSON) { req ->
             uri.path = requestMap.path
             uri.query = requestMap.query
             headers.Accept = requestMap.acceptType
             headers.'Content-Type' = requestMap.contentType
             body = requestMap.body
-            if (requestMap.accessToken){
+            if (requestMap.accessToken) {
                 headers.'Authorization' = 'Bearer ' + requestMap.accessToken
             }
 
@@ -100,29 +110,33 @@ class RestHelper {
                 println resp.headers.'Content-Type'
                 assert resp.statusLine.statusCode == requestMap.statusCode ?: 200
                 def result = reader
-                if (DEBUG) { println result }
+                if (DEBUG) {
+                    println result
+                }
                 return result
             }
 
             response.failure = { resp, reader ->
-                assert resp.statusLine.statusCode == requestMap.statusCode : "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
+                assert resp.statusLine.statusCode == requestMap.statusCode: "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
                 def result = reader
-                if (DEBUG){ println result }
+                if (DEBUG) {
+                    println result
+                }
                 return result
             }
         }
     }
 
-    static get(HTTPBuilder http, Map requestMap){
+    static get(HTTPBuilder http, Map requestMap) {
         http.request(Method.GET) { req ->
-            if(requestMap.path == PATH_OBSERVATIONS && !requestMap.query.type) {
+            if (requestMap.path == PATH_OBSERVATIONS && !requestMap.query.type) {
                 requestMap.query.type = 'clinical'
             }
 
             uri.path = requestMap.path
             uri.query = requestMap.query
             headers.Accept = requestMap.acceptType
-            if (requestMap.accessToken){
+            if (requestMap.accessToken) {
                 headers.'Authorization' = 'Bearer ' + requestMap.accessToken
             }
 
@@ -132,53 +146,63 @@ class RestHelper {
                 println resp.statusLine.statusCode
                 println resp.headers.'Content-Type'
                 assert resp.statusLine.statusCode == requestMap.statusCode ?: 200
-                assert resp.headers.'Content-Type'.contains(requestMap.acceptType) : "response was successful but not what was expected. if type = html: either login failed or the endpoint is not in your application.groovy file"
+                assert resp.headers.'Content-Type'.contains(requestMap.acceptType): "response was successful but not what was expected. if type = html: either login failed or the endpoint is not in your application.groovy file"
                 def result
-                switch (requestMap.acceptType){
-                    case ContentTypeFor.Protobuf:
+                switch (requestMap.acceptType) {
+                    case contentTypeForProtobuf:
                         result = parseProto(resp.entity.content)
                         break
-                    case ContentTypeFor.JSON:
+                    case contentTypeForJSON:
                         result = reader
                         break
                     default:
                         result = reader
                 }
-                if (DEBUG) { println result }
+                if (DEBUG) {
+                    println result
+                }
                 return result
             }
 
             response.failure = { resp, reader ->
-                assert resp.statusLine.statusCode == requestMap.statusCode : "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
+                assert resp.statusLine.statusCode == requestMap.statusCode: "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
                 def result = reader
-                if (DEBUG){ println result }
+                if (DEBUG) {
+                    println result
+                }
                 return result
             }
         }
     }
 
-    static def parseProto(s_in){
+    static def parseProto(s_in) {
         def header = ObservationsProto.Header.parseDelimitedFrom(s_in)
-        if(header.error) throw new RuntimeException("Error in protobuf header message: "+header.error)
-        if (header.dimensionDeclarationsCount == 0){
+        if (header.error) throw new RuntimeException("Error in protobuf header message: " + header.error)
+        if (header.dimensionDeclarationsCount == 0) {
             return new ObservationsMessageProto()
         }
-        if (DEBUG){println('proto header = ' + header)}
+        if (DEBUG) {
+            println('proto header = ' + header)
+        }
         boolean last = header.last
         def cells = []
         int count = 0
-        while(!last) {
+        while (!last) {
             count++
             def cell = ObservationsProto.Cell.parseDelimitedFrom(s_in)
             assert cell != null, "null cell found"
-            if(cell.error) throw new RuntimeException("Error in protobuf cell message: "+cell.error)
+            if (cell.error) throw new RuntimeException("Error in protobuf cell message: " + cell.error)
             last = cell.last
             cells << cell
         }
-        if (DEBUG){println('proto cells = ' + cells)}
+        if (DEBUG) {
+            println('proto cells = ' + cells)
+        }
         def footer = ObservationsProto.Footer.parseDelimitedFrom(s_in)
-        if(footer.error) throw new RuntimeException("Error in protobuf footer message: "+footer.error)
-        if (DEBUG){println('proto footer = ' + footer)}
+        if (footer.error) throw new RuntimeException("Error in protobuf footer message: " + footer.error)
+        if (DEBUG) {
+            println('proto footer = ' + footer)
+        }
 
         return new ObservationsMessageProto(header, cells, footer)
     }

--- a/transmart-rest-api-e2e/src/test/groovy/base/RestHelper.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/base/RestHelper.groovy
@@ -1,0 +1,185 @@
+package base
+
+import groovyx.net.http.ContentType
+import groovyx.net.http.HTTPBuilder
+import groovyx.net.http.Method
+import org.transmartproject.rest.hypercubeProto.ObservationsProto
+import selectors.ObservationsMessageProto
+
+import static config.Config.DEBUG
+import static config.Config.PATH_OBSERVATIONS
+
+class RestHelper {
+
+    static oauth2Authenticate(HTTPBuilder http, userCredentials){
+        def json = post(http, [
+                path: 'oauth/token',
+                acceptType: ContentTypeFor.JSON,
+                query: ['grant_type': 'password', 'client_id': 'glowingbear-js', 'client_secret': '', 'username': userCredentials.'username', 'password': userCredentials.'password'],
+                skipOauth: true
+        ])
+
+        if (DEBUG){
+            println "Authenticate: username=${userCredentials.'username'} password=${userCredentials.'password'} token=${json.access_token}"
+        }
+
+        [userCredentials.username, json.access_token]
+    }
+
+    static delete(HTTPBuilder http, Map requestMap){
+        http.request(Method.DELETE) { req ->
+            uri.path = requestMap.path
+            uri.query = requestMap.query
+            if (requestMap.accessToken){
+                headers.'Authorization' = 'Bearer ' + requestMap.accessToken
+            }
+
+            println(uri.toString())
+            response.success = { resp, reader ->
+                println resp.statusLine.statusCode
+                println resp.headers.'Content-Type'
+                assert resp.statusLine.statusCode == requestMap.statusCode ?: 200
+                def result
+                result = reader
+                if (DEBUG) { println result }
+                return result
+            }
+
+            response.failure = { resp, reader ->
+                assert resp.statusLine.statusCode == requestMap.statusCode : "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
+                def result = reader
+                if (DEBUG){ println result }
+                return result
+            }
+        }
+    }
+
+    static put(HTTPBuilder http, Map requestMap){
+        http.request(Method.PUT, ContentType.JSON) { req ->
+            uri.path = requestMap.path
+            uri.query = requestMap.query
+            headers.Accept = requestMap.acceptType
+            body = requestMap.body
+            if (requestMap.accessToken){
+                headers.'Authorization' = 'Bearer ' + requestMap.accessToken
+            }
+
+            println(uri.toString())
+            response.success = { resp, reader ->
+                println resp.statusLine.statusCode
+                println resp.headers.'Content-Type'
+                assert resp.statusLine.statusCode == requestMap.statusCode ?: 200
+                def result = reader
+                if (DEBUG) { println result }
+                return result
+            }
+
+            response.failure = { resp, reader ->
+                assert resp.statusLine.statusCode == requestMap.statusCode : "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
+                def result = reader
+                if (DEBUG){ println result }
+                return result
+            }
+        }
+    }
+
+    static post(HTTPBuilder http, Map requestMap){
+        http.request(Method.POST, ContentType.JSON) { req ->
+            uri.path = requestMap.path
+            uri.query = requestMap.query
+            headers.Accept = requestMap.acceptType
+            headers.'Content-Type' = requestMap.contentType
+            body = requestMap.body
+            if (requestMap.accessToken){
+                headers.'Authorization' = 'Bearer ' + requestMap.accessToken
+            }
+
+            println(uri.toString())
+            response.success = { resp, reader ->
+                println resp.statusLine.statusCode
+                println resp.headers.'Content-Type'
+                assert resp.statusLine.statusCode == requestMap.statusCode ?: 200
+                def result = reader
+                if (DEBUG) { println result }
+                return result
+            }
+
+            response.failure = { resp, reader ->
+                assert resp.statusLine.statusCode == requestMap.statusCode : "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
+                def result = reader
+                if (DEBUG){ println result }
+                return result
+            }
+        }
+    }
+
+    static get(HTTPBuilder http, Map requestMap){
+        http.request(Method.GET) { req ->
+            if(requestMap.path == PATH_OBSERVATIONS && !requestMap.query.type) {
+                requestMap.query.type = 'clinical'
+            }
+
+            uri.path = requestMap.path
+            uri.query = requestMap.query
+            headers.Accept = requestMap.acceptType
+            if (requestMap.accessToken){
+                headers.'Authorization' = 'Bearer ' + requestMap.accessToken
+            }
+
+
+            println(uri.toString())
+            response.success = { resp, reader ->
+                println resp.statusLine.statusCode
+                println resp.headers.'Content-Type'
+                assert resp.statusLine.statusCode == requestMap.statusCode ?: 200
+                assert resp.headers.'Content-Type'.contains(requestMap.acceptType) : "response was successful but not what was expected. if type = html: either login failed or the endpoint is not in your application.groovy file"
+                def result
+                switch (requestMap.acceptType){
+                    case contentTypeForProtobuf:
+                        result = parseProto(resp.entity.content)
+                        break
+                    case contentTypeForJSON:
+                        result = reader
+                        break
+                    default:
+                        result = reader
+                }
+                if (DEBUG) { println result }
+                return result
+            }
+
+            response.failure = { resp, reader ->
+                assert resp.statusLine.statusCode == requestMap.statusCode : "Expected statusCode: ${requestMap.statusCode} got: ${resp.statusLine.statusCode} with body: ${reader}"
+                def result = reader
+                if (DEBUG){ println result }
+                return result
+            }
+        }
+    }
+
+    static def parseProto(s_in){
+        def header = ObservationsProto.Header.parseDelimitedFrom(s_in)
+        if(header.error) throw new RuntimeException("Error in protobuf header message: "+header.error)
+        if (header.dimensionDeclarationsCount == 0){
+            return new ObservationsMessageProto()
+        }
+        if (DEBUG){println('proto header = ' + header)}
+        boolean last = header.last
+        def cells = []
+        int count = 0
+        while(!last) {
+            count++
+            def cell = ObservationsProto.Cell.parseDelimitedFrom(s_in)
+            assert cell != null, "null cell found"
+            if(cell.error) throw new RuntimeException("Error in protobuf cell message: "+cell.error)
+            last = cell.last
+            cells << cell
+        }
+        if (DEBUG){println('proto cells = ' + cells)}
+        def footer = ObservationsProto.Footer.parseDelimitedFrom(s_in)
+        if(footer.error) throw new RuntimeException("Error in protobuf footer message: "+footer.error)
+        if (DEBUG){println('proto footer = ' + footer)}
+
+        return new ObservationsMessageProto(header, cells, footer)
+    }
+}

--- a/transmart-rest-api-e2e/src/test/groovy/config/Config.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/config/Config.groovy
@@ -40,6 +40,7 @@ class Config {
     public static final String EHR_ID = 'EHR'
     public static final String EHR_HIGHDIM_ID = 'EHR_HIGHDIM'
     public static final String CLINICAL_TRIAL_ID = 'CLINICAL_TRIAL'
+    public static final String CLINICAL_TRIAL_HIGHDIM_ID = 'CLINICAL_TRIAL_HIGHDIM'
     public static final String CATEGORICAL_VALUES_ID = 'CATEGORICAL_VALUES'
     public static final String TUMOR_NORMAL_SAMPLES_ID = 'TUMOR_NORMAL_SAMPLES'
     public static final String SHARED_CONCEPTS_A_ID = 'SHARED_CONCEPTS_STUDY_A'
@@ -58,15 +59,4 @@ class Config {
     public static final boolean SUPPRESS_KNOWN_BUGS = true
     public static final boolean SUPPRESS_UNIMPLEMENTED = true
 
-    //test studies loaded
-    public static final boolean ORACLE_1000_PATIENT_LOADED = false
-    public static final boolean GSE8581_LOADED = false
-    public static final boolean CELL_LINE_LOADED = false
-    public static final boolean EHR_LOADED = true
-    public static final boolean EHR_HIGHDIM_LOADED = true
-    public static final boolean CLINICAL_TRIAL_LOADED = true
-    public static final boolean CATEGORICAL_VALUES_LOADED = true
-    public static final boolean TUMOR_NORMAL_SAMPLES_LOADED = true
-    public static final boolean SHARED_CONCEPTS_LOADED = true
-    public static final boolean SHARED_CONCEPTS_RESTRICTED_LOADED = true
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v1/ConceptsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v1/ConceptsSpec.groovy
@@ -1,32 +1,27 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v1
 
+import annotations.RequiresStudy
 import base.RESTSpec
 
-import spock.lang.Requires
-
-import static config.Config.ADMIN_PASSWORD
-import static config.Config.ADMIN_USERNAME
-import static config.Config.EHR_ID
-import static config.Config.EHR_LOADED
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.GSE8581_ID
-import static config.Config.GSE8581_LOADED
 import static config.Config.V1_PATH_STUDIES
 
-@Requires({GSE8581_LOADED})
-class ConceptsSpec extends RESTSpec{
+@RequiresStudy(GSE8581_ID)
+class ConceptsSpec extends RESTSpec {
 
     /**
      *  given: "study GSE8581 is loaded"
      *  when: "I request all concepts related to this study"
      *  then: "I get all relevant concepts"
      */
-    def "v1 all concepts"(){
+    def "v1 all concepts"() {
         given: "study EHR is loaded"
         def studieId = GSE8581_ID
 
         when: "I request all concepts related to this study"
-        def responseData = get([path: V1_PATH_STUDIES+"/${studieId}/concepts", acceptType: contentTypeForJSON])
+        def responseData = get([path: V1_PATH_STUDIES + "/${studieId}/concepts", acceptType: contentTypeForJSON])
 
         then: "I get all relevant concepts"
         responseData.ontology_terms.each {
@@ -40,13 +35,13 @@ class ConceptsSpec extends RESTSpec{
      *  when: "I request one concept related to this study"
      *  then: "I get the requested concept"
      */
-    def "v1 single concept"(){
+    def "v1 single concept"() {
         given: "study EHR is loaded"
         def studieId = GSE8581_ID
         def conceptPath = "Subjects/Age/"
 
         when: "I request one concept related to this study"
-        def responseData = get([path: V1_PATH_STUDIES+"/${studieId}/concepts/${conceptPath}", acceptType: contentTypeForJSON])
+        def responseData = get([path: V1_PATH_STUDIES + "/${studieId}/concepts/${conceptPath}", acceptType: contentTypeForJSON])
 
         then: "I get the requested concept"
         assert responseData.name == "Age"

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v1/HighDimSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v1/HighDimSpec.groovy
@@ -1,33 +1,31 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v1
 
+import annotations.RequiresStudy
 import base.RESTSpec
-
 import org.apache.http.conn.EofSensorInputStream
-import spock.lang.Requires
 
-import static config.Config.CELL_LINE_ID
-import static config.Config.CELL_LINE_LOADED
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForoctetStream
 import static config.Config.GSE8581_ID
-import static config.Config.GSE8581_LOADED
 import static config.Config.V1_PATH_STUDIES
 
-@Requires({GSE8581_LOADED})
-class HighDimSpec extends RESTSpec{
+@RequiresStudy(GSE8581_ID)
+class HighDimSpec extends RESTSpec {
 
     /**
      *  given: "study CELL-LINE is loaded"
      *  when: "I request all highdim dataTypes for a concept"
      *  then: "I get all relevant dataTypes"
      */
-    def "v1 highdim dataTypes"(){
+    def "v1 highdim dataTypes"() {
         given: "study GSE8581 is loaded"
 
         def studieId = GSE8581_ID
         def conceptPath = 'Biomarker Data/Affymetrix Human Genome U133 Plus 2.0 Array/Lung/'
 
         when: "I request all highdim dataTypes for a concept"
-        def responseData = get([path: V1_PATH_STUDIES+"/${studieId}/concepts/${conceptPath}/highdim", acceptType: contentTypeForJSON])
+        def responseData = get([path: V1_PATH_STUDIES + "/${studieId}/concepts/${conceptPath}/highdim", acceptType: contentTypeForJSON])
 
         then: "I get all relevant dataTypes"
         assert responseData.dataTypes.each {
@@ -44,17 +42,17 @@ class HighDimSpec extends RESTSpec{
      *  when: "I request highdim data"
      *  then: "I get a file stream"
      */
-    def "v1 single "(){
+    def "v1 single "() {
         given: "study GSE8581 is loaded"
         def studieId = GSE8581_ID
         def conceptPath = 'Biomarker Data/Affymetrix Human Genome U133 Plus 2.0 Array/Lung/'
 
         when: "I request highdim data"
         def responseData = get([
-                path: V1_PATH_STUDIES+"/${studieId}/concepts/${conceptPath}/highdim",
-                query: [
-                        dataType: 'mrna',
-                        projection: 'default_real_projection',
+                path      : V1_PATH_STUDIES + "/${studieId}/concepts/${conceptPath}/highdim",
+                query     : [
+                        dataType        : 'mrna',
+                        projection      : 'default_real_projection',
                         assayConstraints: toJSON([patient_id_list: [ids: ["GSE8581GSM210196"]]])
                 ],
                 acceptType: contentTypeForoctetStream

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v1/ObservationsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v1/ObservationsSpec.groovy
@@ -1,33 +1,34 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v1
 
+import annotations.RequiresStudy
 import base.RESTSpec
 import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.*
 
-@Requires({GSE8581_LOADED})
-class ObservationsSpec extends RESTSpec{
+@RequiresStudy(GSE8581_ID)
+class ObservationsSpec extends RESTSpec {
 
     /**
      *  given: "study GSE8581 is loaded"
      *  when: "I request all observations related to a patient and concept"
      *  then: "I get all relevant observations"
      */
-    @Requires({GSE8581_ID})
-    def "v1 observations by query map"(){
+    def "v1 observations by query map"() {
         given: "study GSE8581 is loaded"
         def path = "\\Public Studies\\GSE8581\\Subjects\\Age\\"
         def id = get([
-                path: V1_PATH_STUDIES+"/${GSE8581_ID}/subjects",
+                path      : V1_PATH_STUDIES + "/${GSE8581_ID}/subjects",
                 acceptType: contentTypeForJSON
         ]).subjects[0].id
 
         when: "I request all observations related to a patient and concept"
         def responseData = get([
-                path: V1_PATH_observations,
-                query: [
-                        patients: [id],
+                path      : V1_PATH_observations,
+                query     : [
+                        patients     : [id],
                         concept_paths: [path]
                 ],
                 acceptType: contentTypeForJSON
@@ -45,8 +46,7 @@ class ObservationsSpec extends RESTSpec{
      *  when: "I request all observations related to this study and concept"
      *  then: "I get observations"
      */
-    @Requires({GSE8581_ID})
-    def "v1 observations by concept"(){
+    def "v1 observations by concept"() {
         given: "study GSE8581 is loaded"
         def studyId = GSE8581_ID
         def conceptPath = 'Subjects/Age/'
@@ -63,7 +63,6 @@ class ObservationsSpec extends RESTSpec{
         }
     }
 
-
     /**
      *  given: "study GSE8581 is loaded"
      *  when: "I request all observations related to this study"
@@ -71,13 +70,13 @@ class ObservationsSpec extends RESTSpec{
      *
      *  Highdim data in 17.1 is linked via modifiers, these trigger this error.
      */
-    @Requires({GSE8581_ID && DB_MIGRATED})
-    def "v1 observations by study"(){
+    @Requires({ DB_MIGRATED })
+    def "v1 observations by study"() {
         given: "study GSE8581 is loaded"
         def studyId = GSE8581_ID
 
         when: "I request all observations related to this study"
-        def responseData = get([path: V1_PATH_STUDIES+"/${studyId}/observations", acceptType: contentTypeForJSON, statusCode: 500])
+        def responseData = get([path: V1_PATH_STUDIES + "/${studyId}/observations", acceptType: contentTypeForJSON, statusCode: 500])
 
         then: "I get observations"
         assert responseData.httpStatus == 500

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v1/PatientSetsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v1/PatientSetsSpec.groovy
@@ -1,16 +1,14 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v1
 
+import annotations.RequiresStudy
 import base.RESTSpec
 
-import spock.lang.Requires
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForXML
+import static config.Config.*
 
-import static config.Config.ADMIN_PASSWORD
-import static config.Config.ADMIN_USERNAME
-import static config.Config.EHR_LOADED
-import static config.Config.V1_PATH_PATIENT_SETS
-
-@Requires({EHR_LOADED})
+@RequiresStudy(EHR_ID)
 class PatientSetsSpec extends RESTSpec {
 
     /**
@@ -20,22 +18,22 @@ class PatientSetsSpec extends RESTSpec {
      */
     def "v1 post patient set"() {
         given: "study EHR is loaded"
-        setUser(ADMIN_USERNAME,ADMIN_PASSWORD)
+        setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def body = '<ns4:query_definition xmlns:ns4="http://www.i2b2.org/xsd/cell/crc/psm/1.1/"><specificity_scale>0</specificity_scale><panel><panel_number></panel_number><invert>0</invert><total_item_occurrences>1</total_item_occurrences><item><item_name>Heart Rate</item_name><item_key>\\\\Vital Signs\\Vital Signs\\Heart Rate\\</item_key><tooltip>\\Vital Signs\\Heart Rate\\</tooltip><hlevel>1</hlevel><class>ENC</class></item><panel_timing>ANY</panel_timing></panel><panel><panel_number>2</panel_number><invert>0</invert><total_item_occurrences>1</total_item_occurrences><item><item_name>Age</item_name><item_key>\\\\Public Studies\\Public Studies\\SHARED_CONCEPTS_STUDY_A\\Demography\\Age\\</item_key><tooltip>\\Public Studies\\SHARED_CONCEPTS_STUDY_A\\Demography\\Age\\</tooltip><hlevel>3</hlevel><class>ENC</class><constrain_by_value><value_operator>LT</value_operator><value_constraint>70</value_constraint><value_unit_of_measure>ratio</value_unit_of_measure><value_type>NUMBER</value_type></constrain_by_value></item><panel_timing>ANY</panel_timing></panel><query_timing>ANY</query_timing></ns4:query_definition>'
 
         when: "I create a patient set"
         def responseData = post([
-                path: V1_PATH_PATIENT_SETS,
+                path       : V1_PATH_PATIENT_SETS,
                 contentType: contentTypeForXML,
-                body: body,
-                statusCode: 201
+                body       : body,
+                statusCode : 201
         ])
 
         then: "a set is created and returned"
         assert responseData.id != null
         assert responseData.patients.size() == 2
         responseData.patients.each {
-            assert [-67,-57].contains(it.id)
+            assert [-67, -57].contains(it.id)
         }
     }
 
@@ -46,18 +44,18 @@ class PatientSetsSpec extends RESTSpec {
      */
     def "v1 get patient set"() {
         given: "study EHR is loaded"
-        setUser(ADMIN_USERNAME,ADMIN_PASSWORD)
+        setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def body = '<ns4:query_definition xmlns:ns4="http://www.i2b2.org/xsd/cell/crc/psm/1.1/"><specificity_scale>0</specificity_scale><panel><panel_number></panel_number><invert>0</invert><total_item_occurrences>1</total_item_occurrences><item><item_name>Heart Rate</item_name><item_key>\\\\Vital Signs\\Vital Signs\\Heart Rate\\</item_key><tooltip>\\Vital Signs\\Heart Rate\\</tooltip><hlevel>1</hlevel><class>ENC</class></item><panel_timing>ANY</panel_timing></panel><panel><panel_number>2</panel_number><invert>0</invert><total_item_occurrences>1</total_item_occurrences><item><item_name>Age</item_name><item_key>\\\\Public Studies\\Public Studies\\SHARED_CONCEPTS_STUDY_A\\Demography\\Age\\</item_key><tooltip>\\Public Studies\\SHARED_CONCEPTS_STUDY_A\\Demography\\Age\\</tooltip><hlevel>3</hlevel><class>ENC</class><constrain_by_value><value_operator>LT</value_operator><value_constraint>70</value_constraint><value_unit_of_measure>ratio</value_unit_of_measure><value_type>NUMBER</value_type></constrain_by_value></item><panel_timing>ANY</panel_timing></panel><query_timing>ANY</query_timing></ns4:query_definition>'
         def id = post([
-                path: V1_PATH_PATIENT_SETS,
+                path       : V1_PATH_PATIENT_SETS,
                 contentType: contentTypeForXML,
-                body: body,
-                statusCode: 201
+                body       : body,
+                statusCode : 201
         ]).id
 
         when: "I get a patient set by id"
         def responseData = get([
-                path: V1_PATH_PATIENT_SETS + "/${id}",
+                path      : V1_PATH_PATIENT_SETS + "/${id}",
                 acceptType: contentTypeForJSON
         ])
 
@@ -65,7 +63,7 @@ class PatientSetsSpec extends RESTSpec {
         assert responseData.id == id
         assert responseData.patients.size() == 2
         responseData.patients.each {
-            assert [-67,-57].contains(it.id)
+            assert [-67, -57].contains(it.id)
         }
     }
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v1/StudySpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v1/StudySpec.groovy
@@ -1,32 +1,27 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v1
 
+import annotations.RequiresStudy
 import base.RESTSpec
 
-import spock.lang.Requires
-
-import static config.Config.ADMIN_PASSWORD
-import static config.Config.ADMIN_USERNAME
-import static config.Config.EHR_HIGHDIM_LOADED
-import static config.Config.EHR_LOADED
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.GSE8581_ID
-import static config.Config.GSE8581_LOADED
 import static config.Config.V1_PATH_STUDIES
 
-@Requires({GSE8581_LOADED})
-class StudySpec extends RESTSpec{
+@RequiresStudy(GSE8581_ID)
+class StudySpec extends RESTSpec {
 
     /**
      *  given: "several studies are loaded"
      *  when: "I request all studies"
      *  then: "I get all studies I have access to"
      */
-    def "v1 all studies"(){
+    def "v1 all studies"() {
         given: "several studies are loaded"
 
         when: "I request all studies"
         def responseData = get([
-                path: V1_PATH_STUDIES,
+                path      : V1_PATH_STUDIES,
                 acceptType: contentTypeForJSON
         ])
 
@@ -45,13 +40,13 @@ class StudySpec extends RESTSpec{
      *  when: "I request studies with id EHR"
      *  then: "only the EHR study is returned"
      */
-    def "v1 single study"(){
+    def "v1 single study"() {
         given: "study EHR is loaded"
         def studieId = GSE8581_ID
 
         when: "I request studies with id EHR"
         def responseData = get([
-                path: V1_PATH_STUDIES+"/${studieId}",
+                path      : V1_PATH_STUDIES + "/${studieId}",
                 acceptType: contentTypeForJSON
         ])
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v1/SubjectsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v1/SubjectsSpec.groovy
@@ -1,34 +1,28 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v1
 
+import annotations.RequiresStudy
 import base.RESTSpec
 
-import spock.lang.Requires
+import static base.ContentTypeFor.contentTypeForJSON
+import static config.Config.*
 
-import static config.Config.ADMIN_PASSWORD
-import static config.Config.ADMIN_USERNAME
-import static config.Config.EHR_ID
-import static config.Config.EHR_LOADED
-import static config.Config.GSE8581_ID
-import static config.Config.GSE8581_LOADED
-import static config.Config.V1_PATH_STUDIES
-
-@Requires({GSE8581_LOADED})
-class SubjectsSpec extends RESTSpec{
+@RequiresStudy(GSE8581_ID)
+class SubjectsSpec extends RESTSpec {
 
     /**
      *  given: "study EHR is loaded"
      *  when: "I request subjects related to this study"
      *  then: "subjects are returned"
      */
-    def "v1 subjects"(){
+    def "v1 subjects"() {
         given: "study EHR is loaded"
-        setUser(ADMIN_USERNAME,ADMIN_PASSWORD)
+        setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def studyId = GSE8581_ID
 
         when: "I request subjects related to this study"
         def responseData = get([
-                path: V1_PATH_STUDIES+"/${studyId}/subjects",
+                path      : V1_PATH_STUDIES + "/${studyId}/subjects",
                 acceptType: contentTypeForJSON
         ])
 
@@ -53,19 +47,19 @@ class SubjectsSpec extends RESTSpec{
      *  when: "I request a subject by it's id"
      *  then: "only that subject is returned"
      */
-    def "v1 single subject"(){
+    def "v1 single subject"() {
         given: "study EHR is loaded"
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def studyId = GSE8581_ID
 
         when: "I request a subject by it's id"
         def subjectId = get([
-                path: V1_PATH_STUDIES+"/${studyId}/subjects",
+                path      : V1_PATH_STUDIES + "/${studyId}/subjects",
                 acceptType: contentTypeForJSON
         ]).subjects[0].id
 
         def responseData = get([
-                path: V1_PATH_STUDIES+"/${studyId}/subjects/${subjectId}",
+                path      : V1_PATH_STUDIES + "/${studyId}/subjects/${subjectId}",
                 acceptType: contentTypeForJSON
         ])
 
@@ -87,15 +81,15 @@ class SubjectsSpec extends RESTSpec{
      *  when: "I request subjects related to this study and a concept path"
      *  then: "subjects are returned"
      */
-    def "v1 subjects by concept"(){
+    def "v1 subjects by concept"() {
         given: "study EHR is loaded"
-        setUser(ADMIN_USERNAME,ADMIN_PASSWORD)
+        setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def studyId = GSE8581_ID
         def conceptPath = "Subjects/Age/"
 
         when: "I request subjects related to this study and a concept path"
         def responseData = get([
-                path: V1_PATH_STUDIES+"/${studyId}/concepts/${conceptPath}/subjects",
+                path      : V1_PATH_STUDIES + "/${studyId}/concepts/${conceptPath}/subjects",
                 acceptType: contentTypeForJSON
         ])
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/AggregatedSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/AggregatedSpec.groovy
@@ -1,9 +1,10 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.*
 import static tests.rest.v2.QueryType.*
 import static tests.rest.v2.constraints.ConceptConstraint
@@ -16,25 +17,26 @@ import static tests.rest.v2.constraints.ConceptConstraint
  *      maximum
  *      average
  */
-class AggregatedSpec extends RESTSpec{
+class AggregatedSpec extends RESTSpec {
 
     /**
      *  given: "study EHR is loaded"
      *  when: "for that study I Aggregated the concept Heart Rate with type max"
      *  then: "the number 102.0 is returned"
      */
-    @Requires({EHR_LOADED})
-    def "aggregated timeseries maximum"(){
+    @RequiresStudy(EHR_ID)
+    def "aggregated timeseries maximum"() {
+
         given: "study EHR is loaded"
         def request = [
-                path: PATH_AGGREGATE,
+                path      : PATH_AGGREGATE,
                 acceptType: contentTypeForJSON,
-                query: [
+                query     : [
                         constraint: toJSON([
                                 type: ConceptConstraint,
-                                path:"\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"
+                                path: "\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"
                         ]),
-                        type: MAX
+                        type      : MAX
                 ]
         ]
 
@@ -50,18 +52,18 @@ class AggregatedSpec extends RESTSpec{
      *  when: "for that study I Aggregated the concept Heart Rate with type min"
      *  then: "the number 56.0 is returned"
      */
-    @Requires({EHR_LOADED})
-    def "aggregated timeseries minimum"(){
+    @RequiresStudy(EHR_ID)
+    def "aggregated timeseries minimum"() {
         given: "study EHR is loaded"
         def request = [
-                path: PATH_AGGREGATE,
+                path      : PATH_AGGREGATE,
                 acceptType: contentTypeForJSON,
-                query: [
+                query     : [
                         constraint: toJSON([
                                 type: ConceptConstraint,
-                                path:"\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"
+                                path: "\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"
                         ]),
-                        type: MIN
+                        type      : MIN
                 ]
         ]
 
@@ -77,18 +79,18 @@ class AggregatedSpec extends RESTSpec{
      *  when: "for that study I Aggregated the concept Heart Rate with type average"
      *  then: "the number 74.77777777777777 is returned"
      */
-    @Requires({EHR_LOADED})
-    def "aggregated timeseries average"(){
+    @RequiresStudy(EHR_ID)
+    def "aggregated timeseries average"() {
         given: "study EHR is loaded"
         def request = [
-                path: PATH_AGGREGATE,
+                path      : PATH_AGGREGATE,
                 acceptType: contentTypeForJSON,
-                query: [
+                query     : [
                         constraint: toJSON([
                                 type: ConceptConstraint,
-                                path:"\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"
+                                path: "\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"
                         ]),
-                        type: AVERAGE
+                        type      : AVERAGE
                 ]
         ]
 
@@ -104,16 +106,16 @@ class AggregatedSpec extends RESTSpec{
      *  when: "for that study I Aggregated the concept Heart Rate without a type"
      *  then: "an error is returned"
      */
-    @Requires({EHR_LOADED})
-    def "aggregated missing type"(){
+    @RequiresStudy(EHR_ID)
+    def "aggregated missing type"() {
         given: "study EHR is loaded"
         def request = [
-                path: PATH_AGGREGATE,
+                path      : PATH_AGGREGATE,
                 acceptType: contentTypeForJSON,
-                query: [
+                query     : [
                         constraint: toJSON([
                                 type: ConceptConstraint,
-                                path:"\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"
+                                path: "\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"
                         ])
                 ],
                 statusCode: 400
@@ -133,16 +135,16 @@ class AggregatedSpec extends RESTSpec{
      *  when: "for that study I Aggregated the concept Heart Rate with type average"
      *  then: "I get an access error"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED})
-    def "restricted aggregated average"(){
+    @RequiresStudy(SHARED_CONCEPTS_RESTRICTED_ID)
+    def "restricted aggregated average"() {
         given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I do not have access"
         def conceptPath = '\\Private Studies\\SHARED_CONCEPTS_STUDY_C_PRIV\\Demography\\Age\\'
         def request = [
-                path: PATH_AGGREGATE,
+                path      : PATH_AGGREGATE,
                 acceptType: contentTypeForJSON,
-                query: [
+                query     : [
                         constraint: toJSON([type: ConceptConstraint, path: conceptPath]),
-                        type: AVERAGE
+                        type      : AVERAGE
                 ],
                 statusCode: 403
         ]
@@ -161,17 +163,17 @@ class AggregatedSpec extends RESTSpec{
      *  when: "for that study I Aggregated the concept Heart Rate with type average"
      *  then: "I get an average"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED})
+    @RequiresStudy(SHARED_CONCEPTS_RESTRICTED_ID)
     def "unrestricted aggregated average"() {
         given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I have access"
         setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
         def conceptPath = '\\Private Studies\\SHARED_CONCEPTS_STUDY_C_PRIV\\Demography\\Age\\'
         def request = [
-                path: PATH_AGGREGATE,
+                path      : PATH_AGGREGATE,
                 acceptType: contentTypeForJSON,
-                query: [
+                query     : [
                         constraint: toJSON([type: ConceptConstraint, path: conceptPath]),
-                        type: AVERAGE
+                        type      : AVERAGE
                 ]
         ]
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/BigStudySpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/BigStudySpec.groovy
@@ -1,37 +1,38 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
 import static config.Config.*
 import static tests.rest.v2.Operator.AND
 import static tests.rest.v2.Operator.LESS_THAN
 import static tests.rest.v2.ValueType.NUMERIC
 import static tests.rest.v2.constraints.*
 
-
 /**
  * these test are here to test the correct handling of the max number of sub queries on oracle.
  */
-@Requires({ORACLE_1000_PATIENT_LOADED})
-class BigStudySpec extends RESTSpec{
+@RequiresStudy(ORACLE_1000_PATIENT_ID)
+class BigStudySpec extends RESTSpec {
 
-    def "get 1000 patients"(){
+    def "get 1000 patients"() {
         def request = [
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
+                        args    : [
                                 [type: StudyNameConstraint, studyId: ORACLE_1000_PATIENT_ID],
-                                [type: FieldConstraint,
-                                 field: [dimension: 'patient',
-                                         fieldName: 'age',
-                                         type: NUMERIC ],
+                                [type    : FieldConstraint,
+                                 field   : [dimension: 'patient',
+                                            fieldName: 'age',
+                                            type     : NUMERIC],
                                  operator: LESS_THAN,
-                                 value:70]
+                                 value   : 70]
                         ]
                 ]),
                 statusCode: 200
@@ -48,22 +49,22 @@ class BigStudySpec extends RESTSpec{
 
     }
 
-    def "get observations for 1000 patients"(){
+    def "get observations for 1000 patients"() {
 
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
+                        args    : [
                                 [type: StudyNameConstraint, studyId: ORACLE_1000_PATIENT_ID],
-                                [type: FieldConstraint,
-                                 field: [dimension: 'patient',
-                                         fieldName: 'age',
-                                         type: NUMERIC ],
+                                [type    : FieldConstraint,
+                                 field   : [dimension: 'patient',
+                                            fieldName: 'age',
+                                            type     : NUMERIC],
                                  operator: LESS_THAN,
-                                 value:70]
+                                 value   : 70]
                         ]
                 ]),
                 statusCode: 200
@@ -80,8 +81,8 @@ class BigStudySpec extends RESTSpec{
         println(selector.cellCount)
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/CohortSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/CohortSpec.groovy
@@ -1,24 +1,27 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2
 
+import annotations.RequiresStudy
 import base.RESTSpec
 
+import static base.ContentTypeFor.contentTypeForJSON
+import static config.Config.CATEGORICAL_VALUES_ID
 import static config.Config.PATH_PATIENTS
 import static tests.rest.v2.Operator.AND
 import static tests.rest.v2.Operator.EQUALS
 import static tests.rest.v2.ValueType.STRING
 import static tests.rest.v2.constraints.*
 
+@RequiresStudy(CATEGORICAL_VALUES_ID)
 class CohortSpec extends RESTSpec {
 
-
-    def "get males that are caucasian the wrong way"(){
+    def "get males that are caucasian the wrong way"() {
         def caucasian = [
-                type: Combination,
+                type    : Combination,
                 operator: AND,
-                args: [
+                args    : [
                         [type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Race\\"],
-                        [type: ValueConstraint, valueType: STRING, operator: EQUALS, value:'Caucasian']
+                        [type: ValueConstraint, valueType: STRING, operator: EQUALS, value: 'Caucasian']
                 ]
         ]
 
@@ -26,13 +29,12 @@ class CohortSpec extends RESTSpec {
 
 
         def constraintMap = [
-                type: Combination,
+                type    : Combination,
                 operator: AND,
-                args: [
+                args    : [
                         caucasian, male
                 ]
         ]
-
 
         when:
         def responseData = get([path: PATH_PATIENTS, acceptType: contentTypeForJSON, query: toQuery(constraintMap)])
@@ -41,13 +43,13 @@ class CohortSpec extends RESTSpec {
         assert responseData.patients.size() == 0
     }
 
-    def "get males that are caucasian the right way"(){
+    def "get males that are caucasian the right way"() {
         def caucasian = [
-                type: Combination,
+                type    : Combination,
                 operator: AND,
-                args: [
+                args    : [
                         [type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Race\\"],
-                        [type: ValueConstraint, valueType: STRING, operator: EQUALS, value:'Caucasian']
+                        [type: ValueConstraint, valueType: STRING, operator: EQUALS, value: 'Caucasian']
                 ]
         ]
 
@@ -60,9 +62,9 @@ class CohortSpec extends RESTSpec {
         }
 
         def male = [
-                type: Combination,
+                type    : Combination,
                 operator: AND,
-                args: [
+                args    : [
                         [type: PatientSetConstraint, patientIds: patientIds],
                         [type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Gender\\Male\\"]
                 ]
@@ -73,7 +75,7 @@ class CohortSpec extends RESTSpec {
 
         then: "1 patient is returned"
 
-        def expected = [age:26, birthDate:null, deathDate:null, id:-60, inTrialId:'1', maritalStatus:null, race:'Caucasian', religion:null, sex:'MALE', trial:'CATEGORICAL_VALUES']
+        def expected = [age: 26, birthDate: null, deathDate: null, id: -60, inTrialId: '1', maritalStatus: null, race: 'Caucasian', religion: null, sex: 'MALE', trial: 'CATEGORICAL_VALUES']
         assert responseData.patients.size() == 1
         assert responseData.patients[0].equals(expected)
     }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/ObservationCountsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/ObservationCountsSpec.groovy
@@ -1,26 +1,27 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.*
 import static tests.rest.v2.constraints.ConceptConstraint
 
-class ObservationCountsSpec extends RESTSpec{
+@RequiresStudy(SHARED_CONCEPTS_RESTRICTED_ID)
+class ObservationCountsSpec extends RESTSpec {
 
     /**
      *  given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I do not have access"
      *  when: "I count observations for the concept Heart Rate"
      *  then: "I get a count including observations from the restricted study"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED})
     def "restricted count"() {
         given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I do not have access"
         def request = [
-                path: PATH_COUNTS,
+                path      : PATH_COUNTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"])
         ]
 
         when: "I count observations for the concept Heart Rate"
@@ -35,14 +36,13 @@ class ObservationCountsSpec extends RESTSpec{
      *  when: "I count observations for the concept Heart Rate"
      *  then: "I get a count including observations from the restricted study"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED})
     def "unrestricted count"() {
         given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I have access"
         setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
         def request = [
-                path: PATH_COUNTS,
+                path      : PATH_COUNTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"])
         ]
 
         when: "I count observations for the concept Heart Rate"

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/PatientsCategoricalSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/PatientsCategoricalSpec.groovy
@@ -1,10 +1,11 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
-import static config.Config.CATEGORICAL_VALUES_LOADED
+import static base.ContentTypeFor.contentTypeForJSON
+import static config.Config.CATEGORICAL_VALUES_ID
 import static config.Config.PATH_PATIENTS
 import static org.hamcrest.Matchers.*
 import static spock.util.matcher.HamcrestSupport.that
@@ -18,20 +19,20 @@ import static tests.rest.v2.constraints.*
  *      enabling fetching patients and observations where a categorical variable has a certain value.
  *      E.g., fetching data for patients with value 'female' for 'Sex' or with value 'Unknown' for 'Diagnosis'.
  */
-class PatientsCategoricalSpec extends RESTSpec{
+@RequiresStudy(CATEGORICAL_VALUES_ID)
+class PatientsCategoricalSpec extends RESTSpec {
 
     /**
      *  given: "study CATEGORICAL_VALUES is loaded where Gender is stored in the old data format"
      *  when: "I get all patients from the study that have concept Gender"
      *  then: "no patients are returned"
      */
-    @Requires({CATEGORICAL_VALUES_LOADED})
-    def "get patient using old data format new style query"(){
+    def "get patient using old data format new style query"() {
         given: "study CATEGORICAL_VALUES is loaded where Gender is stored in the old data format"
         def request = [
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Gender\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Gender\\"])
         ]
 
         when: "I get all patients from the  study that have concept Gender"
@@ -46,13 +47,12 @@ class PatientsCategoricalSpec extends RESTSpec{
      *  when: "I get all patients from the study that have concept Gender\Female"
      *  then: "1 patient is returned"
      */
-    @Requires({CATEGORICAL_VALUES_LOADED})
-    def "get patient using old data format old style query"(){
+    def "get patient using old data format old style query"() {
         given: "study CATEGORICAL_VALUES is loaded where Gender is stored in the old data format"
         def request = [
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Gender\\Female\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Gender\\Female\\"])
         ]
 
         when: "I get all patients from the study that have concept Female"
@@ -68,13 +68,12 @@ class PatientsCategoricalSpec extends RESTSpec{
      *  when: "I get all patients from the study that have concept Race"
      *  then: "2 patients are returned"
      */
-    @Requires({CATEGORICAL_VALUES_LOADED})
-    def "get patient using new data format new style query"(){
+    def "get patient using new data format new style query"() {
         given: "study CATEGORICAL_VALUES is loaded where Gender is stored in the new data format"
         def request = [
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Race\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Race\\"])
         ]
 
         when: "I get all patients from the study that have concept Race"
@@ -90,18 +89,17 @@ class PatientsCategoricalSpec extends RESTSpec{
      *  when: "I get all patients from the study that have concept Race with value Caucasian"
      *  then: "2 patients are returned"
      */
-    @Requires({CATEGORICAL_VALUES_LOADED})
-    def "get patient using new data format new style query with value"(){
+    def "get patient using new data format new style query with value"() {
         given: "study CATEGORICAL_VALUES is loaded where Gender is stored in the new data format"
         def request = [
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
+                        args    : [
                                 [type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Race\\"],
-                                [type: ValueConstraint, valueType: STRING, operator: EQUALS, value:'Caucasian']
+                                [type: ValueConstraint, valueType: STRING, operator: EQUALS, value: 'Caucasian']
                         ]
                 ])
         ]

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/PatientsSetSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/PatientsSetSpec.groovy
@@ -1,9 +1,10 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.*
 import static tests.rest.v2.Operator.AND
 import static tests.rest.v2.Operator.GREATER_THAN
@@ -17,19 +18,19 @@ class PatientsSetSpec extends RESTSpec {
      *  when: "I make a patientset with age greater then greater then 30"
      *  then: "I get a patientset with 2 patients"
      */
-    @Requires({EHR_LOADED})
-    def "create patientset"(){
+    @RequiresStudy(EHR_ID)
+    def "create patientset"() {
         given: "study EHR is loaded"
         def request = [
-                path: PATH_PATIENT_SET,
+                path      : PATH_PATIENT_SET,
                 acceptType: contentTypeForJSON,
-                query: [name: 'test_set'],
-                body: toJSON([
-                        type: Combination,
+                query     : [name: 'test_set'],
+                body      : toJSON([
+                        type    : Combination,
                         operator: AND,
-                        args: [
-                                [type: ConceptConstraint, path:"\\Public Studies\\EHR\\Demography\\Age\\"],
-                                [type: ValueConstraint, valueType: NUMERIC, operator: GREATER_THAN, value:30]
+                        args    : [
+                                [type: ConceptConstraint, path: "\\Public Studies\\EHR\\Demography\\Age\\"],
+                                [type: ValueConstraint, valueType: NUMERIC, operator: GREATER_THAN, value: 30]
                         ]
                 ]),
                 statusCode: 201
@@ -39,11 +40,11 @@ class PatientsSetSpec extends RESTSpec {
         def responseData = post(request)
 
         then: "I get a patientset with 2 patients"
-        assert  responseData.id != null
+        assert responseData.id != null
         assert get([
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: PatientSetConstraint, patientSetId: responseData.id])
+                query     : toQuery([type: PatientSetConstraint, patientSetId: responseData.id])
         ]).patients.size() == 2
 
     }
@@ -53,14 +54,14 @@ class PatientsSetSpec extends RESTSpec {
      *  when: "I make a patient set with a shared concept"
      *  then: "the set has patients from several studies"
      */
-    @Requires({SHARED_CONCEPTS_LOADED})
-    def "create patient set shared concepts"(){
+    @RequiresStudy([SHARED_CONCEPTS_A_ID, SHARED_CONCEPTS_B_ID, SHARED_CONCEPTS_RESTRICTED_ID])
+    def "create patient set shared concepts"() {
         given: "Studies with shared concepts is loaded"
         def request = [
-                path: PATH_PATIENT_SET,
+                path      : PATH_PATIENT_SET,
                 acceptType: contentTypeForJSON,
-                query: [name: 'test_set'],
-                body: toJSON([type: ConceptConstraint, path:"\\Vital Signs\\Heart Rate\\"]),
+                query     : [name: 'test_set'],
+                body      : toJSON([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"]),
                 statusCode: 201
         ]
 
@@ -68,11 +69,11 @@ class PatientsSetSpec extends RESTSpec {
         def responseData = post(request)
 
         then: "the set has patients from several studies"
-        assert  responseData.id != null
+        assert responseData.id != null
         assert get([
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: PatientSetConstraint, patientSetId: responseData.id])
+                query     : toQuery([type: PatientSetConstraint, patientSetId: responseData.id])
         ]).patients.size() == 4
     }
 
@@ -81,14 +82,14 @@ class PatientsSetSpec extends RESTSpec {
      *  when: "I make a patient set with a shared concept"
      *  then: "the set has patients from the studies I have access to"
      */
-    @Requires({SHARED_CONCEPTS_LOADED && SHARED_CONCEPTS_RESTRICTED_LOADED})
-    def "create patient set shared concepts restricted"(){
+    @RequiresStudy([SHARED_CONCEPTS_A_ID, SHARED_CONCEPTS_B_ID, SHARED_CONCEPTS_RESTRICTED_ID])
+    def "create patient set shared concepts restricted"() {
         given: "Studies with shared concepts is loaded and I have acces to some"
         def request = [
-                path: PATH_PATIENT_SET,
+                path      : PATH_PATIENT_SET,
                 acceptType: contentTypeForJSON,
-                query: [name: 'test_set'],
-                body: toJSON([type: ConceptConstraint, path:"\\Vital Signs\\Heart Rate\\"]),
+                query     : [name: 'test_set'],
+                body      : toJSON([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"]),
                 statusCode: 201
         ]
 
@@ -96,11 +97,11 @@ class PatientsSetSpec extends RESTSpec {
         def responseData = post(request)
 
         then: "the set has patients from the studies I have access to"
-        assert  responseData.id != null
+        assert responseData.id != null
         assert get([
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: PatientSetConstraint, patientSetId: responseData.id])
+                query     : toQuery([type: PatientSetConstraint, patientSetId: responseData.id])
         ]).patients.size() == 4
     }
 
@@ -109,15 +110,15 @@ class PatientsSetSpec extends RESTSpec {
      *  when: "I make a patient set with a shared concept"
      *  then: "the set has patients from all studies with the shared concept"
      */
-    @Requires({SHARED_CONCEPTS_LOADED && SHARED_CONCEPTS_RESTRICTED_LOADED})
-    def "create patient set shared concepts unrestricted"(){
+    @RequiresStudy([SHARED_CONCEPTS_A_ID, SHARED_CONCEPTS_B_ID, SHARED_CONCEPTS_RESTRICTED_ID])
+    def "create patient set shared concepts unrestricted"() {
         given: "Studies with shared concepts is loaded and I have access to all"
         setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
         def request = [
-                path: PATH_PATIENT_SET,
+                path      : PATH_PATIENT_SET,
                 acceptType: contentTypeForJSON,
-                query: [name: 'test_set'],
-                body: toJSON([type: ConceptConstraint, path:"\\Vital Signs\\Heart Rate\\"]),
+                query     : [name: 'test_set'],
+                body      : toJSON([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"]),
                 statusCode: 201
         ]
 
@@ -125,11 +126,11 @@ class PatientsSetSpec extends RESTSpec {
         def responseData = post(request)
 
         then: "the set has patients from all studies with the shared concept"
-        assert  responseData.id != null
+        assert responseData.id != null
         assert get([
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: PatientSetConstraint, patientSetId: responseData.id])
+                query     : toQuery([type: PatientSetConstraint, patientSetId: responseData.id])
         ]).patients.size() == 6
     }
 
@@ -139,25 +140,25 @@ class PatientsSetSpec extends RESTSpec {
      *  then: "I get a access error"
      */
     //TODO: A cleaner error would be nice
-    @Requires({SHARED_CONCEPTS_LOADED && SHARED_CONCEPTS_RESTRICTED_LOADED})
-    def "using patient by user without access"(){
+    @RequiresStudy([SHARED_CONCEPTS_A_ID, SHARED_CONCEPTS_B_ID, SHARED_CONCEPTS_RESTRICTED_ID])
+    def "using patient by user without access"() {
         given: "Studies with shared concepts is loaded and I have access to some"
         setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
         def request = [
-                path: PATH_PATIENT_SET,
+                path      : PATH_PATIENT_SET,
                 acceptType: contentTypeForJSON,
-                query: [name: 'test_set'],
-                body: toJSON([type: ConceptConstraint, path:"\\Vital Signs\\Heart Rate\\"]),
+                query     : [name: 'test_set'],
+                body      : toJSON([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"]),
                 statusCode: 201
         ]
         def setID = post(request)
         setUser(DEFAULT_USERNAME, DEFAULT_PASSWORD)
 
         when: "When I use a patient set that contains patients that I do not have access to"
-        def responseData =  get([
-                path: PATH_PATIENTS,
+        def responseData = get([
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: PatientSetConstraint, patientSetId: setID]),
+                query     : toQuery([type: PatientSetConstraint, patientSetId: setID]),
                 statusCode: 400
         ])
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/PatientsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/PatientsSpec.groovy
@@ -1,9 +1,10 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.*
 import static org.hamcrest.Matchers.*
 import static spock.util.matcher.HamcrestSupport.that
@@ -17,25 +18,25 @@ import static tests.rest.v2.constraints.*
  *      The REST API should support querying patients based on observations:
  *          certain constraints are valid for any or for all observations for the patient. E.g, all observations of high blood pressure occur after supply of drug X.
  */
-class PatientsSpec extends RESTSpec{
+class PatientsSpec extends RESTSpec {
 
     /**
      *  given: "study CLINICAL_TRIAL is loaded"
      *  when: "I get all patients from that study with a heart rate above 80"
      *  then: "2 patients are returned"
      */
-    @Requires({CLINICAL_TRIAL_LOADED})
-    def "get patients based on observations"(){
+    @RequiresStudy(CLINICAL_TRIAL_ID)
+    def "get patients based on observations"() {
         given: "study CLINICAL_TRIAL is loaded"
         def request = [
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
-                                [type: ConceptConstraint, path:"\\Public Studies\\CLINICAL_TRIAL\\Vital Signs\\Heart Rate\\"],
-                                [type: ValueConstraint, valueType: NUMERIC, operator: GREATER_THAN, value:80]
+                        args    : [
+                                [type: ConceptConstraint, path: "\\Public Studies\\CLINICAL_TRIAL\\Vital Signs\\Heart Rate\\"],
+                                [type: ValueConstraint, valueType: NUMERIC, operator: GREATER_THAN, value: 80]
                         ]
                 ])
         ]
@@ -53,24 +54,24 @@ class PatientsSpec extends RESTSpec{
      *  when: "I get all patients from that study that had a heart rate above 60 after 7 days (after trial visit 2)"
      *  then: "2 patients are returned"
      */
-    @Requires({CLINICAL_TRIAL_LOADED})
-    def "get patients by trial visit observation value"(){
+    @RequiresStudy(CLINICAL_TRIAL_ID)
+    def "get patients by trial visit observation value"() {
         given: "study CLINICAL_TRIAL is loaded"
         def request = [
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
-                                [type: ConceptConstraint, path:"\\Public Studies\\CLINICAL_TRIAL\\Vital Signs\\Heart Rate\\"],
-                                [type: ValueConstraint, valueType: NUMERIC, operator: GREATER_THAN, value:60],
-                                [type: FieldConstraint,
-                                 field: [dimension: 'trial visit',
-                                         fieldName: 'relTime',
-                                         type: NUMERIC ],
+                        args    : [
+                                [type: ConceptConstraint, path: "\\Public Studies\\CLINICAL_TRIAL\\Vital Signs\\Heart Rate\\"],
+                                [type: ValueConstraint, valueType: NUMERIC, operator: GREATER_THAN, value: 60],
+                                [type    : FieldConstraint,
+                                 field   : [dimension: 'trial visit',
+                                            fieldName: 'relTime',
+                                            type     : NUMERIC],
                                  operator: GREATER_THAN,
-                                 value:7]
+                                 value   : 7]
                         ]
                 ])
         ]
@@ -88,13 +89,13 @@ class PatientsSpec extends RESTSpec{
      *  when: "I try to get the patients from that study"
      *  then: "I get an access error"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED})
-    def "get pratients restricted"(){
+    @RequiresStudy(SHARED_CONCEPTS_RESTRICTED_ID)
+    def "get pratients restricted"() {
         given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I do not have access"
         def request = [
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: StudyNameConstraint, studyId: SHARED_CONCEPTS_RESTRICTED_ID]),
+                query     : toQuery([type: StudyNameConstraint, studyId: SHARED_CONCEPTS_RESTRICTED_ID]),
                 statusCode: 403
         ]
 
@@ -112,14 +113,14 @@ class PatientsSpec extends RESTSpec{
      *  when: "I try to get the patients from that study"
      *  then: "I get all patients"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED})
-    def "get pratients unrestricted"(){
+    @RequiresStudy(SHARED_CONCEPTS_RESTRICTED_ID)
+    def "get pratients unrestricted"() {
         given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I do not have access"
         setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
         def request = [
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: StudyNameConstraint, studyId: SHARED_CONCEPTS_RESTRICTED_ID]),
+                query     : toQuery([type: StudyNameConstraint, studyId: SHARED_CONCEPTS_RESTRICTED_ID]),
                 statusCode: 403
         ]
 
@@ -138,11 +139,11 @@ class PatientsSpec extends RESTSpec{
      *  when: "I try to get the patients from that study by id in path"
      *  then: "I get an not found error"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED})
-    def "restricted get patient by id"(){
+    @RequiresStudy(SHARED_CONCEPTS_RESTRICTED_ID)
+    def "restricted get patient by id"() {
         given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I do not have access"
         def request = [
-                path: PATH_PATIENTS+"/-69",
+                path      : PATH_PATIENTS + "/-69",
                 acceptType: contentTypeForJSON,
                 statusCode: 404
         ]
@@ -161,14 +162,14 @@ class PatientsSpec extends RESTSpec{
      *  when: "I try to get the patients from that study by id in path"
      *  then: "I get the patient"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED})
-    def "get patient by id"(){
+    @RequiresStudy(SHARED_CONCEPTS_RESTRICTED_ID)
+    def "get patient by id"() {
         given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I have access"
         setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
 
         when: "I try to get the patients from that study by id in path"
         def responseData = get([
-                path: PATH_PATIENTS+"/-69",
+                path      : PATH_PATIENTS + "/-69",
                 acceptType: contentTypeForJSON
         ])
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/StudiesSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/StudiesSpec.groovy
@@ -1,10 +1,11 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2
 
+import annotations.RequiresStudy
 import base.RESTSpec
 import groovy.util.logging.Slf4j
-import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.*
 
 /**
@@ -13,28 +14,21 @@ import static config.Config.*
  *  This class tests if the /v2/studies endpoint works correctly.
  */
 @Slf4j
-class StudiesSpec extends  RESTSpec{
+@RequiresStudy([SHARED_CONCEPTS_A_ID, SHARED_CONCEPTS_B_ID, SHARED_CONCEPTS_RESTRICTED_ID])
+class StudiesSpec extends RESTSpec {
 
     /**
      *  given: "All studies are loaded and I do have unlimited access"
      *  when: "I try to fetch all studies"
      *  then: "the list of all studies is returned"
      */
-    @Requires({
-        EHR_LOADED &&
-        EHR_HIGHDIM_LOADED &&
-        CLINICAL_TRIAL_LOADED &&
-        CATEGORICAL_VALUES_LOADED &&
-        TUMOR_NORMAL_SAMPLES_LOADED &&
-        SHARED_CONCEPTS_LOADED &&
-        SHARED_CONCEPTS_RESTRICTED_LOADED
-    })
-    def "all studies are returned"(){
+    @RequiresStudy([EHR_ID, EHR_HIGHDIM_ID, CLINICAL_TRIAL_ID, CATEGORICAL_VALUES_ID, TUMOR_NORMAL_SAMPLES_ID, SHARED_CONCEPTS_A_ID, SHARED_CONCEPTS_B_ID, SHARED_CONCEPTS_RESTRICTED_ID])
+    def "all studies are returned"() {
         given: "All studies are loaded and I do have unlimited access"
         setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
         when: "I try to fetch all studies"
         def responseData = get([
-                path: PATH_STUDIES,
+                path      : PATH_STUDIES,
                 acceptType: contentTypeForJSON,
         ])
         def studies = responseData.studies as List
@@ -53,21 +47,13 @@ class StudiesSpec extends  RESTSpec{
      *  when: "I try to fetch all studies"
      *  then: "the list of all unrestricted studies is returned"
      */
-    @Requires({
-        EHR_LOADED &&
-        EHR_HIGHDIM_LOADED &&
-        CLINICAL_TRIAL_LOADED &&
-        CATEGORICAL_VALUES_LOADED &&
-        TUMOR_NORMAL_SAMPLES_LOADED &&
-        SHARED_CONCEPTS_LOADED &&
-        SHARED_CONCEPTS_RESTRICTED_LOADED
-    })
-    def "all unrestricted studies are returned"(){
+    @RequiresStudy([EHR_ID, EHR_HIGHDIM_ID, CLINICAL_TRIAL_ID, CATEGORICAL_VALUES_ID, TUMOR_NORMAL_SAMPLES_ID, SHARED_CONCEPTS_A_ID, SHARED_CONCEPTS_B_ID, SHARED_CONCEPTS_RESTRICTED_ID])
+    def "all unrestricted studies are returned"() {
         given: "All studies are loaded and I do have limited access"
 
         when: "I try to fetch all studies"
         def responseData = get([
-                path: PATH_STUDIES,
+                path      : PATH_STUDIES,
                 acceptType: contentTypeForJSON,
         ])
         def studies = responseData.studies as List
@@ -84,16 +70,12 @@ class StudiesSpec extends  RESTSpec{
      *  when: "I try to fetch study A by id"
      *  then: "the study object is returned"
      */
-    @Requires({
-        SHARED_CONCEPTS_LOADED &&
-        SHARED_CONCEPTS_RESTRICTED_LOADED
-    })
-    def "study is fetched by id"(){
+    def "study is fetched by id"() {
         given: "Shared concepts studies are loaded and I do have limited access"
 
         when: "I try to fetch study A by id"
         def studyResponse = get([
-                path: "${PATH_STUDIES}/${SHARED_CONCEPTS_A_DB_ID}",
+                path      : "${PATH_STUDIES}/${SHARED_CONCEPTS_A_DB_ID}",
                 acceptType: contentTypeForJSON,
         ])
 
@@ -106,17 +88,13 @@ class StudiesSpec extends  RESTSpec{
      *  when: "I try to fetch study A by id"
      *  then: "the study object is returned"
      */
-    @Requires({
-        SHARED_CONCEPTS_LOADED &&
-                SHARED_CONCEPTS_RESTRICTED_LOADED
-    })
-    def "restricted study is fetched by id"(){
+    def "restricted study is fetched by id"() {
         given: "Shared concepts studies are loaded and I do have un limited access"
         setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
 
         when: "I try to fetch study A by id"
         def studyResponse = get([
-                path: "${PATH_STUDIES}/${SHARED_CONCEPTS_RESTRICTED_DB_ID}",
+                path      : "${PATH_STUDIES}/${SHARED_CONCEPTS_RESTRICTED_DB_ID}",
                 acceptType: contentTypeForJSON,
         ])
 
@@ -129,16 +107,12 @@ class StudiesSpec extends  RESTSpec{
      *  when: "I try to fetch study A by id"
      *  then: "the study object is returned"
      */
-    @Requires({
-        SHARED_CONCEPTS_LOADED &&
-                SHARED_CONCEPTS_RESTRICTED_LOADED
-    })
-    def "access denied when restricted study is fetched by id"(){
+    def "access denied when restricted study is fetched by id"() {
         given: "Shared concepts studies are loaded and I do have limited access"
 
         when: "I try to fetch study A by id"
         def studyResponse = get([
-                path: "${PATH_STUDIES}/${SHARED_CONCEPTS_RESTRICTED_DB_ID}",
+                path      : "${PATH_STUDIES}/${SHARED_CONCEPTS_RESTRICTED_DB_ID}",
                 acceptType: contentTypeForJSON,
                 statusCode: 403
         ])
@@ -153,16 +127,12 @@ class StudiesSpec extends  RESTSpec{
      *  when: "I try to fetch study A by studyId"
      *  then: "the study object is returned"
      */
-    @Requires({
-        SHARED_CONCEPTS_LOADED &&
-        SHARED_CONCEPTS_RESTRICTED_LOADED
-    })
-    def "study is fetched by name"(){
+    def "study is fetched by name"() {
         given: "Shared concepts studies are loaded and I do have limited access"
 
         when: "I try to fetch study A by studyId"
         def studyResponse = get([
-                path: "${PATH_STUDIES}/studyId/${SHARED_CONCEPTS_A_ID}",
+                path      : "${PATH_STUDIES}/studyId/${SHARED_CONCEPTS_A_ID}",
                 acceptType: contentTypeForJSON,
         ])
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/SupportedFieldsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/SupportedFieldsSpec.groovy
@@ -1,10 +1,11 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
-import static config.Config.EHR_LOADED
+import static base.ContentTypeFor.contentTypeForJSON
+import static config.Config.EHR_ID
 import static config.Config.PATH_SUPPORTED_FIELDS
 
 class SupportedFieldsSpec extends RESTSpec {
@@ -14,13 +15,13 @@ class SupportedFieldsSpec extends RESTSpec {
      *  when: "I request all supported fields"
      *  then: "I get a list of fields with dimension, fieldName and type"
      */
-    @Requires({EHR_LOADED})
-    def "supported fields"(){
+    @RequiresStudy(EHR_ID)
+    def "supported fields"() {
         given: "any studies are loaded"
 
         when: "I request all supported fields"
         def responseData = get([
-                path: PATH_SUPPORTED_FIELDS,
+                path      : PATH_SUPPORTED_FIELDS,
                 acceptType: contentTypeForJSON
         ])
 
@@ -29,22 +30,22 @@ class SupportedFieldsSpec extends RESTSpec {
             assert supportedFields.contains(it)
         }
     }
-    
-    def supportedFields = [[dimension:'patient', fieldName:'id', type:'ID'], [dimension:'patient', fieldName:'age', type:'NUMERIC'],
-                           [dimension:'patient', fieldName:'race', type:'STRING'], [dimension:'patient', fieldName:'maritalStatus', type:'STRING'],
-                           [dimension:'patient', fieldName:'religion', type:'STRING'], [dimension:'patient', fieldName:'patientBlob', type:'STRING'],
-                           [dimension:'patient', fieldName:'vitalStatusCd', type:'STRING'], [dimension:'patient', fieldName:'birthDate', type:'DATE'],
-                           [dimension:'patient', fieldName:'deathDate', type:'DATE'], [dimension:'patient', fieldName:'sexCd', type:'STRING'], [dimension:'patient', fieldName:'languageCd', type:'STRING'],
-                           [dimension:'patient', fieldName:'zipCd', type:'STRING'], [dimension:'patient', fieldName:'statecityzipPath', type:'STRING'], [dimension:'patient', fieldName:'incomeCd', type:'STRING'],
-                           [dimension:'patient', fieldName:'updateDate', type:'DATE'], [dimension:'patient', fieldName:'downloadDate', type:'DATE'], [dimension:'patient', fieldName:'importDate', type:'DATE'],
-                           [dimension:'patient', fieldName:'sourcesystemCd', type:'STRING'], [dimension:'patient', fieldName:'uploadId', type:'NUMERIC'], [dimension:'concept', fieldName:'conceptCode', type:'STRING'],
-                           [dimension:'visit', fieldName:'encounterNum', type:'NUMERIC'], [dimension:'visit', fieldName:'patient', type:'OBJECT'], [dimension:'visit', fieldName:'activeStatusCd', type:'STRING'],
-                           [dimension:'visit', fieldName:'startDate', type:'DATE'], [dimension:'visit', fieldName:'endDate', type:'DATE'], [dimension:'visit', fieldName:'inoutCd', type:'STRING'],
-                           [dimension:'visit', fieldName:'locationCd', type:'STRING'], [dimension:'visit', fieldName:'locationPath', type:'STRING'], [dimension:'visit', fieldName:'lengthOfStay', type:'NUMERIC'],
-                           [dimension:'visit', fieldName:'visitBlob', type:'STRING'], [dimension:'visit', fieldName:'updateDate', type:'DATE'], [dimension:'visit', fieldName:'downloadDate', type:'DATE'],
-                           [dimension:'visit', fieldName:'importDate', type:'DATE'], [dimension:'visit', fieldName:'sourcesystemCd', type:'STRING'], [dimension:'visit', fieldName:'uploadId', type:'NUMERIC'],
-                           [dimension:'trial visit', fieldName:'id', type:'ID'], [dimension:'trial visit', fieldName:'study', type:'OBJECT'], [dimension:'trial visit', fieldName:'relTimeUnit', type:'STRING'],
-                           [dimension:'trial visit', fieldName:'relTime', type:'NUMERIC'], [dimension:'trial visit', fieldName:'relTimeLabel', type:'STRING'],
-                           [dimension:'location', fieldName:'locationCd', type:'STRING'], [dimension:'provider', fieldName:'providerId', type:'STRING'],
-                           [dimension:'start time', fieldName:'startDate', type:'DATE'], [dimension:'end time', fieldName:'endDate', type:'DATE']]
+
+    def supportedFields = [[dimension: 'patient', fieldName: 'id', type: 'ID'], [dimension: 'patient', fieldName: 'age', type: 'NUMERIC'],
+                           [dimension: 'patient', fieldName: 'race', type: 'STRING'], [dimension: 'patient', fieldName: 'maritalStatus', type: 'STRING'],
+                           [dimension: 'patient', fieldName: 'religion', type: 'STRING'], [dimension: 'patient', fieldName: 'patientBlob', type: 'STRING'],
+                           [dimension: 'patient', fieldName: 'vitalStatusCd', type: 'STRING'], [dimension: 'patient', fieldName: 'birthDate', type: 'DATE'],
+                           [dimension: 'patient', fieldName: 'deathDate', type: 'DATE'], [dimension: 'patient', fieldName: 'sexCd', type: 'STRING'], [dimension: 'patient', fieldName: 'languageCd', type: 'STRING'],
+                           [dimension: 'patient', fieldName: 'zipCd', type: 'STRING'], [dimension: 'patient', fieldName: 'statecityzipPath', type: 'STRING'], [dimension: 'patient', fieldName: 'incomeCd', type: 'STRING'],
+                           [dimension: 'patient', fieldName: 'updateDate', type: 'DATE'], [dimension: 'patient', fieldName: 'downloadDate', type: 'DATE'], [dimension: 'patient', fieldName: 'importDate', type: 'DATE'],
+                           [dimension: 'patient', fieldName: 'sourcesystemCd', type: 'STRING'], [dimension: 'patient', fieldName: 'uploadId', type: 'NUMERIC'], [dimension: 'concept', fieldName: 'conceptCode', type: 'STRING'],
+                           [dimension: 'visit', fieldName: 'encounterNum', type: 'NUMERIC'], [dimension: 'visit', fieldName: 'patient', type: 'OBJECT'], [dimension: 'visit', fieldName: 'activeStatusCd', type: 'STRING'],
+                           [dimension: 'visit', fieldName: 'startDate', type: 'DATE'], [dimension: 'visit', fieldName: 'endDate', type: 'DATE'], [dimension: 'visit', fieldName: 'inoutCd', type: 'STRING'],
+                           [dimension: 'visit', fieldName: 'locationCd', type: 'STRING'], [dimension: 'visit', fieldName: 'locationPath', type: 'STRING'], [dimension: 'visit', fieldName: 'lengthOfStay', type: 'NUMERIC'],
+                           [dimension: 'visit', fieldName: 'visitBlob', type: 'STRING'], [dimension: 'visit', fieldName: 'updateDate', type: 'DATE'], [dimension: 'visit', fieldName: 'downloadDate', type: 'DATE'],
+                           [dimension: 'visit', fieldName: 'importDate', type: 'DATE'], [dimension: 'visit', fieldName: 'sourcesystemCd', type: 'STRING'], [dimension: 'visit', fieldName: 'uploadId', type: 'NUMERIC'],
+                           [dimension: 'trial visit', fieldName: 'id', type: 'ID'], [dimension: 'trial visit', fieldName: 'study', type: 'OBJECT'], [dimension: 'trial visit', fieldName: 'relTimeUnit', type: 'STRING'],
+                           [dimension: 'trial visit', fieldName: 'relTime', type: 'NUMERIC'], [dimension: 'trial visit', fieldName: 'relTimeLabel', type: 'STRING'],
+                           [dimension: 'location', fieldName: 'locationCd', type: 'STRING'], [dimension: 'provider', fieldName: 'providerId', type: 'STRING'],
+                           [dimension: 'start time', fieldName: 'startDate', type: 'DATE'], [dimension: 'end time', fieldName: 'endDate', type: 'DATE']]
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/TreeNodesSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/TreeNodesSpec.groovy
@@ -1,29 +1,30 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.*
 
 /**
  *  TMPREQ-6 Building a tree where concepts are study-specific
  */
-class TreeNodesSpec extends  RESTSpec{
+@RequiresStudy([SHARED_CONCEPTS_A_ID, SHARED_CONCEPTS_B_ID, SHARED_CONCEPTS_RESTRICTED_ID])
+class TreeNodesSpec extends RESTSpec {
 
     /**
      *  given: "Study SHARED_CONCEPTS_STUDY_C_PRIV and SHARED_CONCEPTS_A is loaded, and I have access"
      *  when: "I try to get the tree_nodes from all studies"
      *  then: "nodes from SHARED_CONCEPTS_STUDY_C_PRIV and SHARED_CONCEPTS_A are included"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED && SHARED_CONCEPTS_LOADED})
-    def "restricted tree_nodes are included"(){
+    def "restricted tree_nodes are included"() {
         given: "Study SHARED_CONCEPTS_STUDY_C_PRIV and SHARED_CONCEPTS_A is loaded, and I do not have access"
         setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
 
         when: "I try to get the tree_nodes from all studies"
         def responseData = get([
-                path: PATH_TREE_NODES,
+                path      : PATH_TREE_NODES,
                 acceptType: contentTypeForJSON,
         ])
 
@@ -35,20 +36,17 @@ class TreeNodesSpec extends  RESTSpec{
         assert getChildrenAtributes(studyC, 'name').containsAll([SHARED_CONCEPTS_RESTRICTED_ID, 'Vital Signs', 'Heart Rate', 'Demography', 'Age'])
     }
 
-
-
     /**
      *  given: "Study SHARED_CONCEPTS_STUDY_C_PRIV and SHARED_CONCEPTS_A is loaded, and I do not have access"
      *  when: "I try to get the tree_nodes from all studies"
      *  then: "only nodes from SHARED_CONCEPTS_A are returned"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED && SHARED_CONCEPTS_LOADED})
-    def "restricted tree_nodes are excluded"(){
+    def "restricted tree_nodes are excluded"() {
         given: "Study SHARED_CONCEPTS_STUDY_C_PRIV and SHARED_CONCEPTS_A is loaded, and I do not have access"
 
         when: "I try to get the tree_nodes from all studies"
         def responseData = get([
-                path: PATH_TREE_NODES,
+                path      : PATH_TREE_NODES,
                 acceptType: contentTypeForJSON,
         ])
 
@@ -65,15 +63,14 @@ class TreeNodesSpec extends  RESTSpec{
      *  when: "I get the tree_nodes with a subNode and depth"
      *  then: "only de subNodes of that node are returned"
      */
-    @Requires({SHARED_CONCEPTS_LOADED})
-    def "params limit nodes returned"(){
+    def "params limit nodes returned"() {
         given: "Study SHARED_CONCEPTS is loaded"
 
         when: "I get the tree_nodes with a subNode and depth"
         def responseData = get([
-                path: PATH_TREE_NODES,
+                path      : PATH_TREE_NODES,
                 acceptType: contentTypeForJSON,
-                query: [root : "\\Public Studies\\SHARED_CONCEPTS_STUDY_A\\", depth : 2]
+                query     : [root: "\\Public Studies\\SHARED_CONCEPTS_STUDY_A\\", depth: 2]
         ])
 
         then: "only de subNodes of that node are returned"
@@ -88,15 +85,14 @@ class TreeNodesSpec extends  RESTSpec{
      *  when: "I get the tree_nodes with counts=true"
      *  then: "then concept nodes have observationCount and patientCount"
      */
-    @Requires({SHARED_CONCEPTS_LOADED})
-    def "nodes with counts true"(){
+    def "nodes with counts true"() {
         given: "Study SHARED_CONCEPTS is loaded"
 
         when: "I get the tree_nodes with counts=true"
         def responseData = get([
-                path: PATH_TREE_NODES,
+                path      : PATH_TREE_NODES,
                 acceptType: contentTypeForJSON,
-                query: ['counts' : true]
+                query     : ['counts': true]
         ])
 
         then: "then concept nodes have observationCount and patientCount"
@@ -113,15 +109,14 @@ class TreeNodesSpec extends  RESTSpec{
      *  when: "I get the tree_nodes with counts=true"
      *  then: "then concept nodes have observationCount and patientCount"
      */
-    @Requires({SHARED_CONCEPTS_LOADED})
-    def "shared nodes with counts true restricted"(){
+    def "shared nodes with counts true restricted"() {
         given: "Study SHARED_CONCEPTS is loaded"
 
         when: "I get the tree_nodes with counts=true"
         def responseData = get([
-                path: PATH_TREE_NODES,
+                path      : PATH_TREE_NODES,
                 acceptType: contentTypeForJSON,
-                query: ['counts' : true]
+                query     : ['counts': true]
         ])
 
         then: "then concept nodes have observationCount and patientCount"
@@ -136,16 +131,15 @@ class TreeNodesSpec extends  RESTSpec{
      *  when: "I get the tree_nodes with counts=true"
      *  then: "then concept nodes have observationCount and patientCount"
      */
-    @Requires({SHARED_CONCEPTS_LOADED})
-    def "nodes with counts true unrestricted"(){
+    def "nodes with counts true unrestricted"() {
         given: "Study SHARED_CONCEPTS is loaded"
-        setUser(UNRESTRICTED_USERNAME,UNRESTRICTED_PASSWORD)
+        setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
 
         when: "I get the tree_nodes with counts=true"
         def responseData = get([
-                path: PATH_TREE_NODES,
+                path      : PATH_TREE_NODES,
                 acceptType: contentTypeForJSON,
-                query: ['counts' : true]
+                query     : ['counts': true]
         ])
 
         then: "then concept nodes have observationCount and patientCount"
@@ -160,15 +154,15 @@ class TreeNodesSpec extends  RESTSpec{
      *  when: "I get the tree_nodes with tags=true"
      *  then: "then concept nodes have observationCount and patientCount"
      */
-    @Requires({CELL_LINE_LOADED})
-    def "nodes with tags true"(){
+    @RequiresStudy(CELL_LINE_ID)
+    def "nodes with tags true"() {
         given: "Study SHARED_CONCEPTS is loaded"
 
         when: "I get the tree_nodes with tags=true"
         def responseData = get([
-                path: PATH_TREE_NODES,
+                path      : PATH_TREE_NODES,
                 acceptType: contentTypeForJSON,
-                query: ['tags' : true]
+                query     : ['tags': true]
         ])
 
         then: "then concept nodes have observationCount and patientCount"
@@ -181,16 +175,15 @@ class TreeNodesSpec extends  RESTSpec{
      *  when: "I try to get the tree_nodes from that study"
      *  then: "I get an access error"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED})
     def "restricted tree_nodes"() {
         given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I do not have access"
         def path = "\\Private Studies\\SHARED_CONCEPTS_STUDY_C_PRIV\\"
 
         when: "I try to get the tree_nodes from that study"
         def responseData = get([
-                path: PATH_TREE_NODES,
+                path      : PATH_TREE_NODES,
                 acceptType: contentTypeForJSON,
-                query: [root : path, depth : 1],
+                query     : [root: path, depth: 1],
                 statusCode: 403
         ])
 
@@ -200,25 +193,25 @@ class TreeNodesSpec extends  RESTSpec{
         assert responseData.message == "Access denied to path: ${path}"
     }
 
-    def getRootNodeByName(list, name){
+    def getRootNodeByName(list, name) {
         def root
-        list.tree_nodes.each{
-            if (it.name == name){
+        list.tree_nodes.each {
+            if (it.name == name) {
                 root = it
             }
         }
         return root
     }
 
-    def getNodeByName(root, name){
-        if (root.name == name){
+    def getNodeByName(root, name) {
+        if (root.name == name) {
             return root
         }
         def result
-        if (root.children){
-            root.children.each{
+        if (root.children) {
+            root.children.each {
                 def node = getNodeByName(it, name)
-                if (node){
+                if (node) {
                     result = node
                 }
             }
@@ -226,10 +219,10 @@ class TreeNodesSpec extends  RESTSpec{
         return result
     }
 
-    def getChildrenAtributes(node, attribute){
+    def getChildrenAtributes(node, attribute) {
         def nodeNames = [node.get(attribute)]
-        if (node.children){
-            node.children.each{
+        if (node.children) {
+            node.children.each {
                 nodeNames.addAll(getChildrenAtributes(it, attribute))
             }
         }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/AccessLevelSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/AccessLevelSpec.groovy
@@ -1,29 +1,31 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.hypercube
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
 import static config.Config.*
 import static tests.rest.v2.constraints.ConceptConstraint
 
 /**
  *  TMPREQ-8 Specifying user/group access by study
  */
-@Requires({SHARED_CONCEPTS_RESTRICTED_LOADED})
-class AccessLevelSpec extends RESTSpec{
+@RequiresStudy(SHARED_CONCEPTS_RESTRICTED_ID)
+class AccessLevelSpec extends RESTSpec {
 
     /**
      *  given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I do not have access"
      *  when: "I try to get a concept from that study"
      *  then: "I get an access error"
      */
-    def "restricted access "(def acceptType){
+    def "restricted access "(def acceptType) {
         given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I do not have access"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ConceptConstraint, path: "\\Private Studies\\SHARED_CONCEPTS_STUDY_C_PRIV\\Demography\\Age\\"]),
+                query     : toQuery([type: ConceptConstraint, path: "\\Private Studies\\SHARED_CONCEPTS_STUDY_C_PRIV\\Demography\\Age\\"]),
                 statusCode: 403
         ]
 
@@ -37,8 +39,8 @@ class AccessLevelSpec extends RESTSpec{
         assert responseData.message == 'Access denied to concept path: \\Private Studies\\SHARED_CONCEPTS_STUDY_C_PRIV\\Demography\\Age\\'
 
         where:
-        acceptType | _
-        contentTypeForJSON | _
+        acceptType             | _
+        contentTypeForJSON     | _
         contentTypeForProtobuf | _
     }
 
@@ -47,13 +49,13 @@ class AccessLevelSpec extends RESTSpec{
      *  when: "I try to get a concept from that study"
      *  then: "I get the observations"
      */
-    def "unrestricted access"(def acceptType, def newSelector){
+    def "unrestricted access"(def acceptType, def newSelector) {
         given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I have access"
         setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ConceptConstraint, path: "\\Private Studies\\SHARED_CONCEPTS_STUDY_C_PRIV\\Demography\\Age\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Private Studies\\SHARED_CONCEPTS_STUDY_C_PRIV\\Demography\\Age\\"])
         ]
 
 
@@ -68,8 +70,8 @@ class AccessLevelSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -78,13 +80,13 @@ class AccessLevelSpec extends RESTSpec{
      *  when: "I try to get a concept from that study"
      *  then: "I get the observations"
      */
-    def "unrestricted access admin"(def acceptType, def newSelector){
+    def "unrestricted access admin"(def acceptType, def newSelector) {
         given: "Study SHARED_CONCEPTS_RESTRICTED_LOADED is loaded, and I have access"
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ConceptConstraint, path: "\\Private Studies\\SHARED_CONCEPTS_STUDY_C_PRIV\\Demography\\Age\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Private Studies\\SHARED_CONCEPTS_STUDY_C_PRIV\\Demography\\Age\\"])
         ]
 
 
@@ -100,8 +102,8 @@ class AccessLevelSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/CategoricalVariablesSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/CategoricalVariablesSpec.groovy
@@ -1,10 +1,12 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.hypercube
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
-import static config.Config.CATEGORICAL_VALUES_LOADED
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
+import static config.Config.CATEGORICAL_VALUES_ID
 import static config.Config.PATH_OBSERVATIONS
 import static tests.rest.v2.Operator.AND
 import static tests.rest.v2.Operator.EQUALS
@@ -16,20 +18,20 @@ import static tests.rest.v2.constraints.*
  *      enabling fetching patients and observations where a categorical variable has a certain value.
  *      E.g., fetching data for patients with value 'female' for 'Sex' or with value 'Unknown' for 'Diagnosis'.
  */
-@Requires({CATEGORICAL_VALUES_LOADED})
-class CategoricalVariablesSpec extends RESTSpec{
+@RequiresStudy(CATEGORICAL_VALUES_ID)
+class CategoricalVariablesSpec extends RESTSpec {
 
     /**
      *  given: "study CATEGORICAL_VALUES is loaded where Gender is stored in the old data format"
      *  when: "I get all observations from the study that have concept Gender"
      *  then: "no observations are returned"
      */
-    def "get observations using old data format new style query"(def acceptType){
+    def "get observations using old data format new style query"(def acceptType) {
         given: "study CATEGORICAL_VALUES is loaded where Gender is stored in the old data format"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Gender\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Gender\\"])
         ]
 
         when: "I get all observations from the  study that have concept Gender"
@@ -39,8 +41,8 @@ class CategoricalVariablesSpec extends RESTSpec{
         assert responseData.cells == []
 
         where:
-        acceptType | _
-        contentTypeForJSON | _
+        acceptType             | _
+        contentTypeForJSON     | _
         contentTypeForProtobuf | _
     }
 
@@ -49,12 +51,12 @@ class CategoricalVariablesSpec extends RESTSpec{
      *  when: "I get all observations from the study that have concept Gender\Female"
      *  then: "1 observation is returned"
      */
-    def "get observations using old data format old style query"(){
+    def "get observations using old data format old style query"() {
         given: "study CATEGORICAL_VALUES is loaded where Gender is stored in the old data format"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Gender\\Female\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Gender\\Female\\"])
         ]
 
         when: "I get all observations from the study that have concept Female"
@@ -68,8 +70,8 @@ class CategoricalVariablesSpec extends RESTSpec{
         assert selector.select(0) == 'Female'
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -78,12 +80,12 @@ class CategoricalVariablesSpec extends RESTSpec{
      *  when: "I get all observations from the study that have concept Race"
      *  then: "2 observations are returned"
      */
-    def "get observations using new data format new style query"(){
+    def "get observations using new data format new style query"() {
         given: "study CATEGORICAL_VALUES is loaded where Gender is stored in the new data format"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Race\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Race\\"])
         ]
 
         when: "I get all observations from the study that have concept Race"
@@ -98,8 +100,8 @@ class CategoricalVariablesSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -108,17 +110,17 @@ class CategoricalVariablesSpec extends RESTSpec{
      *  when: "I get all observations from the study that have concept Race with value Caucasian"
      *  then: "2 observations are returned"
      */
-    def "get observations using new data format new style query with value"(){
+    def "get observations using new data format new style query with value"() {
         given: "study CATEGORICAL_VALUES is loaded where Gender is stored in the new data format"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
+                        args    : [
                                 [type: ConceptConstraint, path: "\\Public Studies\\CATEGORICAL_VALUES\\Demography\\Race\\"],
-                                [type: ValueConstraint, valueType: STRING, operator: EQUALS, value:'Caucasian']
+                                [type: ValueConstraint, valueType: STRING, operator: EQUALS, value: 'Caucasian']
                         ]
                 ])
         ]
@@ -136,8 +138,8 @@ class CategoricalVariablesSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/ConstraintSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/ConstraintSpec.groovy
@@ -2,8 +2,9 @@
 package tests.rest.v2.hypercube
 
 import base.RESTSpec
-import spock.lang.Ignore
 
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
 import static config.Config.*
 import static org.hamcrest.Matchers.is
 import static spock.util.matcher.HamcrestSupport.that
@@ -11,7 +12,7 @@ import static tests.rest.v2.Operator.*
 import static tests.rest.v2.ValueType.*
 import static tests.rest.v2.constraints.*
 
-class ConstraintSpec extends RESTSpec{
+class ConstraintSpec extends RESTSpec {
 
     /**
      * TrueConstraint.class,
@@ -36,12 +37,12 @@ class ConstraintSpec extends RESTSpec{
      *  when:" I do a Get query/observations with a wrong type."
      *  then: "then I get a 400 with 'Constraint not supported: BadType.'"
      */
-    def "Get /query/observations malformed query"(){
-        when:" I do a Get query/observations with a wrong type."
+    def "Get /query/observations malformed query"() {
+        when: " I do a Get query/observations with a wrong type."
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: 'BadType']),
+                query     : toQuery([type: 'BadType']),
                 statusCode: 400
         ]
 
@@ -53,16 +54,16 @@ class ConstraintSpec extends RESTSpec{
         that responseData.message, is('Constraint not supported: BadType.')
 
         where:
-        acceptType | _
-        contentTypeForJSON | _
+        acceptType             | _
+        contentTypeForJSON     | _
         contentTypeForProtobuf | _
     }
 
-    def "TrueConstraint.class"(){
+    def "TrueConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: TrueConstraint])
+                query     : toQuery([type: TrueConstraint])
         ]
 
         when:
@@ -76,17 +77,17 @@ class ConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
-    def "ModifierConstraint.class"(){
+    def "ModifierConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: ModifierConstraint, path:"\\Public Studies\\TUMOR_NORMAL_SAMPLES\\Sample Type\\",
+                query     : toQuery([
+                        type  : ModifierConstraint, path: "\\Public Studies\\TUMOR_NORMAL_SAMPLES\\Sample Type\\",
                         values: [type: ValueConstraint, valueType: STRING, operator: EQUALS, value: "Tumor"]
                 ])
         ]
@@ -105,10 +106,10 @@ class ConstraintSpec extends RESTSpec{
 
         when:
         request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: ModifierConstraint, modifierCode: "TNS:SMPL",
+                query     : toQuery([
+                        type  : ModifierConstraint, modifierCode: "TNS:SMPL",
                         values: [type: ValueConstraint, valueType: STRING, operator: EQUALS, value: "Tumor"]
                 ])
         ]
@@ -124,21 +125,21 @@ class ConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
-    def "FieldConstraint.class"(){
+    def "FieldConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: FieldConstraint,
-                                field: [dimension: 'patient',
-                                        fieldName: 'age',
-                                        type: NUMERIC ],
-                                operator: EQUALS,
-                                value:30])
+                query     : toQuery([type    : FieldConstraint,
+                                     field   : [dimension: 'patient',
+                                                fieldName: 'age',
+                                                type     : NUMERIC],
+                                     operator: EQUALS,
+                                     value   : 30])
         ]
 
         when:
@@ -151,16 +152,16 @@ class ConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
-    def "ValueConstraint.class"(){
+    def "ValueConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ValueConstraint, valueType: NUMERIC, operator: GREATER_THAN, value:176])
+                query     : toQuery([type: ValueConstraint, valueType: NUMERIC, operator: GREATER_THAN, value: 176])
         ]
 
         when:
@@ -173,19 +174,19 @@ class ConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
-    def "TimeConstraint.class"(){
+    def "TimeConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: TimeConstraint,
-                                field: [dimension: 'start time', fieldName: 'startDate', type: DATE ],
-                                operator: AFTER,
-                                values: [toDateString("01-01-2016Z")]])
+                query     : toQuery([type    : TimeConstraint,
+                                     field   : [dimension: 'start time', fieldName: 'startDate', type: DATE],
+                                     operator: AFTER,
+                                     values  : [toDateString("01-01-2016Z")]])
         ]
 
         when:
@@ -198,25 +199,25 @@ class ConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
-    def "PatientSetConstraint.class"(){
+    def "PatientSetConstraint.class"() {
         def postRequest = [
-                path: PATH_PATIENT_SET,
-                acceptType: contentTypeForJSON,
+                path          : PATH_PATIENT_SET,
+                acceptType    : contentTypeForJSON,
                 'Content-Type': contentTypeForJSON,
-                query: [name: 'test_PatientSetConstraint'],
-                body: toJSON([type: PatientSetConstraint, patientIds: -62])
+                query         : [name: 'test_PatientSetConstraint'],
+                body          : toJSON([type: PatientSetConstraint, patientIds: -62])
         ]
         def setID = post(postRequest)
 
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: PatientSetConstraint, patientSetId: setID.id])
+                query     : toQuery([type: PatientSetConstraint, patientSetId: setID.id])
         ]
 
         when:
@@ -230,9 +231,9 @@ class ConstraintSpec extends RESTSpec{
 
         when:
         request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: PatientSetConstraint, patientIds: -62])
+                query     : toQuery([type: PatientSetConstraint, patientIds: -62])
         ]
         responseData = get(request)
         selector = newSelector(responseData)
@@ -243,18 +244,18 @@ class ConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
-    def "Negation.class"(){
+    def "Negation.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
+                query     : toQuery([
                         type: Negation,
-                        arg: [type: PatientSetConstraint, patientIds: [-62, -52, -42]]
+                        arg : [type: PatientSetConstraint, patientIds: [-62, -52, -42]]
                 ])
         ]
 
@@ -268,19 +269,19 @@ class ConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
-    def "Combination.class"(){
+    def "Combination.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
+                        args    : [
                                 [type: PatientSetConstraint, patientSetId: 0, patientIds: -62],
                                 [type: ConceptConstraint, path: "\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"]
                         ]
@@ -297,23 +298,23 @@ class ConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
-    def "TemporalConstraint.class"(){
+    def "TemporalConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: TemporalConstraint,
-                        operator: AFTER,
+                query     : toQuery([
+                        type           : TemporalConstraint,
+                        operator       : AFTER,
                         eventConstraint: [
-                                type: ValueConstraint,
+                                type     : ValueConstraint,
                                 valueType: NUMERIC,
-                                operator: LESS_THAN,
-                                value: 60
+                                operator : LESS_THAN,
+                                value    : 60
                         ]
                 ])
         ]
@@ -328,19 +329,19 @@ class ConstraintSpec extends RESTSpec{
         (0..<selector.cellCount).each {
             conceptCodes.add selector.select(it, "concept", "conceptCode", 'String')
         }
-        assert conceptCodes.containsAll("EHR:VSIGN:HR","EHRHD:VSIGN:HR","EHRHD:HD:EXPLUNG","EHRHD:HD:EXPBREAST")
+        assert conceptCodes.containsAll("EHR:VSIGN:HR", "EHRHD:VSIGN:HR", "EHRHD:HD:EXPLUNG", "EHRHD:HD:EXPBREAST")
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
-    def "ConceptConstraint.class"(){
+    def "ConceptConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ConceptConstraint, path: "\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"])
         ]
 
         when:
@@ -353,16 +354,16 @@ class ConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
-    def "StudyConstraint.class"(){
+    def "StudyConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: StudyNameConstraint, studyId: EHR_ID])
+                query     : toQuery([type: StudyNameConstraint, studyId: EHR_ID])
         ]
 
         when:
@@ -375,35 +376,35 @@ class ConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
-    def "NullConstraint.class"(){
+    def "NullConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: NullConstraint,
-                        field: [dimension: 'end time', fieldName: 'endDate', type: DATE ]
+                query     : toQuery([
+                        type : NullConstraint,
+                        field: [dimension: 'end time', fieldName: 'endDate', type: DATE]
                 ])
         ]
-        
+
         when:
         def responseData = get(request)
         def selector = newSelector(responseData)
 
         then:
-        HashSet conceptCodes= []
+        HashSet conceptCodes = []
         (0..<selector.cellCount).each {
             conceptCodes.add(selector.select(it, "concept", "conceptCode", 'String'))
         }
         assert conceptCodes.containsAll(['CV:DEM:SEX:M', 'CV:DEM:SEX:F', 'CV:DEM:RACE', 'CV:DEM:AGE'])
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/DeserializationSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/DeserializationSpec.groovy
@@ -1,20 +1,24 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.hypercube
 
+import annotations.RequiresStudy
 import base.RESTSpec
 
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
 import static config.Config.*
 import static tests.rest.v2.Operator.OR
 import static tests.rest.v2.constraints.Combination
 import static tests.rest.v2.constraints.StudyNameConstraint
 
-class DeserializationSpec extends RESTSpec{
+@RequiresStudy(CATEGORICAL_VALUES_ID)
+class DeserializationSpec extends RESTSpec {
 
-    def "reconstruct observations"(){
+    def "reconstruct observations"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: StudyNameConstraint, studyId: CATEGORICAL_VALUES_ID])
+                query     : toQuery([type: StudyNameConstraint, studyId: CATEGORICAL_VALUES_ID])
         ]
 
         when:
@@ -25,30 +29,31 @@ class DeserializationSpec extends RESTSpec{
 
         (0..<selector.cellCount).each {
             def temp = [
-                    'sex' : selector.select(it, "patient", "sex", 'String'),
-                    'race' : selector.select(it, "patient", "race", 'String'),
-                    'age' : selector.select(it, "patient", "age", 'Int'),
-                    'study' : selector.select(it, "study", "name", 'String'),
-                    'conceptCode' : selector.select(it, "concept", "conceptCode", 'String'),
-                    'value' : selector.select(it)
+                    'sex'        : selector.select(it, "patient", "sex", 'String'),
+                    'race'       : selector.select(it, "patient", "race", 'String'),
+                    'age'        : selector.select(it, "patient", "age", 'Int'),
+                    'study'      : selector.select(it, "study", "name", 'String'),
+                    'conceptCode': selector.select(it, "concept", "conceptCode", 'String'),
+                    'value'      : selector.select(it)
             ]
             assert result.contains(temp)
         }
 
         where:
-        acceptType | newSelector | result
-        contentTypeForJSON | jsonSelector | CATEGORICAL_VALUES_OBSERVATIONS_json
+        acceptType             | newSelector      | result
+        contentTypeForJSON     | jsonSelector     | CATEGORICAL_VALUES_OBSERVATIONS_json
         contentTypeForProtobuf | protobufSelector | CATEGORICAL_VALUES_OBSERVATIONS_proto
     }
 
-    def "reconstruct observations multi study"(){
+    @RequiresStudy(CLINICAL_TRIAL_ID)
+    def "reconstruct observations multi study"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: OR,
-                        args: [
+                        args    : [
                                 [type: StudyNameConstraint, studyId: CATEGORICAL_VALUES_ID],
                                 [type: StudyNameConstraint, studyId: CLINICAL_TRIAL_ID]
                         ]
@@ -62,80 +67,80 @@ class DeserializationSpec extends RESTSpec{
         then:
 
         def map = []
-            map.addAll(map1)
-            map.addAll(map2)
+        map.addAll(map1)
+        map.addAll(map2)
 
         (0..<selector.cellCount).each {
             def temp = [
-                    'sex' : selector.select(it, "patient", "sex", 'String'),
-                    'race' : selector.select(it, "patient", "race", 'String'),
-                    'age' : selector.select(it, "patient", "age", 'Int'),
-                    'study' : selector.select(it, "study", "name", 'String'),
-                    'conceptCode' : selector.select(it, "concept", "conceptCode", 'String'),
-                    'value' : selector.select(it)
+                    'sex'        : selector.select(it, "patient", "sex", 'String'),
+                    'race'       : selector.select(it, "patient", "race", 'String'),
+                    'age'        : selector.select(it, "patient", "age", 'Int'),
+                    'study'      : selector.select(it, "study", "name", 'String'),
+                    'conceptCode': selector.select(it, "concept", "conceptCode", 'String'),
+                    'value'      : selector.select(it)
             ]
             assert map.contains(temp)
         }
 
         where:
-        acceptType | newSelector | map1 | map2
-        contentTypeForJSON | jsonSelector | CATEGORICAL_VALUES_OBSERVATIONS_json | CLINICAL_TRIAL_OBSERVATIONS_json
+        acceptType             | newSelector      | map1                                  | map2
+        contentTypeForJSON     | jsonSelector     | CATEGORICAL_VALUES_OBSERVATIONS_json  | CLINICAL_TRIAL_OBSERVATIONS_json
         contentTypeForProtobuf | protobufSelector | CATEGORICAL_VALUES_OBSERVATIONS_proto | CLINICAL_TRIAL_OBSERVATIONS_proto
     }
 
 
     static def CATEGORICAL_VALUES_OBSERVATIONS_json = [
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26, 'conceptCode' : 'CV:DEM:SEX:M', 'value' : 'Male', 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26, 'conceptCode' : 'CV:DEM:RACE', 'value' : 'Caucasian', 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26, 'conceptCode' : 'CV:DEM:AGE', 'value' : new BigDecimal(26), 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'male', 'race' : 'Latino', 'age': 24, 'conceptCode' : 'CV:DEM:SEX:M', 'value' : 'Male', 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'male', 'race' : 'Latino', 'age': 24, 'conceptCode' : 'CV:DEM:RACE', 'value' : 'Latino', 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'male', 'race' : 'Latino', 'age': 24, 'conceptCode' : 'CV:DEM:AGE', 'value' : new BigDecimal(24), 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20, 'conceptCode' : 'CV:DEM:SEX:F', 'value' : 'Female', 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20, 'conceptCode' : 'CV:DEM:RACE', 'value' : 'Caucasian', 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20, 'conceptCode' : 'CV:DEM:AGE', 'value' : new BigDecimal(20), 'study' : 'CATEGORICAL_VALUES']
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26, 'conceptCode': 'CV:DEM:SEX:M', 'value': 'Male', 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26, 'conceptCode': 'CV:DEM:RACE', 'value': 'Caucasian', 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26, 'conceptCode': 'CV:DEM:AGE', 'value': new BigDecimal(26), 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'male', 'race': 'Latino', 'age': 24, 'conceptCode': 'CV:DEM:SEX:M', 'value': 'Male', 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'male', 'race': 'Latino', 'age': 24, 'conceptCode': 'CV:DEM:RACE', 'value': 'Latino', 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'male', 'race': 'Latino', 'age': 24, 'conceptCode': 'CV:DEM:AGE', 'value': new BigDecimal(24), 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20, 'conceptCode': 'CV:DEM:SEX:F', 'value': 'Female', 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20, 'conceptCode': 'CV:DEM:RACE', 'value': 'Caucasian', 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20, 'conceptCode': 'CV:DEM:AGE', 'value': new BigDecimal(20), 'study': 'CATEGORICAL_VALUES']
     ]
 
     static def CLINICAL_TRIAL_OBSERVATIONS_json = [
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26, 'conceptCode' : 'CT:DEM:AGE', 'value' : new BigDecimal(26), 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26, 'conceptCode' : 'CT:VSIGN:HR', 'value' : new BigDecimal(80), 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26, 'conceptCode' : 'CT:VSIGN:HR', 'value' : new BigDecimal(90), 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26, 'conceptCode' : 'CT:VSIGN:HR', 'value' : new BigDecimal(88), 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'male', 'race' : 'Latino', 'age': 24, 'conceptCode' : 'CT:DEM:AGE', 'value' : new BigDecimal(24), 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'male', 'race' : 'Latino', 'age': 24, 'conceptCode' : 'CT:VSIGN:HR', 'value' : new BigDecimal(56), 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'male', 'race' : 'Latino', 'age': 24, 'conceptCode' : 'CT:VSIGN:HR', 'value' : new BigDecimal(57), 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20, 'conceptCode' : 'CT:DEM:AGE', 'value' : new BigDecimal(20), 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20, 'conceptCode' : 'CT:VSIGN:HR', 'value' : new BigDecimal(66), 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20, 'conceptCode' : 'CT:VSIGN:HR', 'value' : new BigDecimal(68), 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20, 'conceptCode' : 'CT:VSIGN:HR', 'value' : new BigDecimal(56), 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20, 'conceptCode' : 'CT:VSIGN:HR', 'value' : new BigDecimal(88), 'study' : 'CLINICAL_TRIAL']
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26, 'conceptCode': 'CT:DEM:AGE', 'value': new BigDecimal(26), 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26, 'conceptCode': 'CT:VSIGN:HR', 'value': new BigDecimal(80), 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26, 'conceptCode': 'CT:VSIGN:HR', 'value': new BigDecimal(90), 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26, 'conceptCode': 'CT:VSIGN:HR', 'value': new BigDecimal(88), 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'male', 'race': 'Latino', 'age': 24, 'conceptCode': 'CT:DEM:AGE', 'value': new BigDecimal(24), 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'male', 'race': 'Latino', 'age': 24, 'conceptCode': 'CT:VSIGN:HR', 'value': new BigDecimal(56), 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'male', 'race': 'Latino', 'age': 24, 'conceptCode': 'CT:VSIGN:HR', 'value': new BigDecimal(57), 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20, 'conceptCode': 'CT:DEM:AGE', 'value': new BigDecimal(20), 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20, 'conceptCode': 'CT:VSIGN:HR', 'value': new BigDecimal(66), 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20, 'conceptCode': 'CT:VSIGN:HR', 'value': new BigDecimal(68), 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20, 'conceptCode': 'CT:VSIGN:HR', 'value': new BigDecimal(56), 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20, 'conceptCode': 'CT:VSIGN:HR', 'value': new BigDecimal(88), 'study': 'CLINICAL_TRIAL']
     ]
 
     static def CATEGORICAL_VALUES_OBSERVATIONS_proto = [
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26L, 'conceptCode' : 'CV:DEM:SEX:M', 'value' : 'Male', 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26L, 'conceptCode' : 'CV:DEM:RACE', 'value' : 'Caucasian', 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26L, 'conceptCode' : 'CV:DEM:AGE', 'value' : 26.0D, 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'male', 'race' : 'Latino', 'age': 24L, 'conceptCode' : 'CV:DEM:SEX:M', 'value' : 'Male', 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'male', 'race' : 'Latino', 'age': 24L, 'conceptCode' : 'CV:DEM:RACE', 'value' : 'Latino', 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'male', 'race' : 'Latino', 'age': 24L, 'conceptCode' : 'CV:DEM:AGE', 'value' : 24.0D, 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20L, 'conceptCode' : 'CV:DEM:SEX:F', 'value' : 'Female', 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20L, 'conceptCode' : 'CV:DEM:RACE', 'value' : 'Caucasian', 'study' : 'CATEGORICAL_VALUES'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20L, 'conceptCode' : 'CV:DEM:AGE', 'value' : 20.0D, 'study' : 'CATEGORICAL_VALUES']
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26L, 'conceptCode': 'CV:DEM:SEX:M', 'value': 'Male', 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26L, 'conceptCode': 'CV:DEM:RACE', 'value': 'Caucasian', 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26L, 'conceptCode': 'CV:DEM:AGE', 'value': 26.0D, 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'male', 'race': 'Latino', 'age': 24L, 'conceptCode': 'CV:DEM:SEX:M', 'value': 'Male', 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'male', 'race': 'Latino', 'age': 24L, 'conceptCode': 'CV:DEM:RACE', 'value': 'Latino', 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'male', 'race': 'Latino', 'age': 24L, 'conceptCode': 'CV:DEM:AGE', 'value': 24.0D, 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20L, 'conceptCode': 'CV:DEM:SEX:F', 'value': 'Female', 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20L, 'conceptCode': 'CV:DEM:RACE', 'value': 'Caucasian', 'study': 'CATEGORICAL_VALUES'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20L, 'conceptCode': 'CV:DEM:AGE', 'value': 20.0D, 'study': 'CATEGORICAL_VALUES']
     ]
 
     static def CLINICAL_TRIAL_OBSERVATIONS_proto = [
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26L, 'conceptCode' : 'CT:DEM:AGE', 'value' : 26.0D, 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26L, 'conceptCode' : 'CT:VSIGN:HR', 'value' : 80.0D, 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26L, 'conceptCode' : 'CT:VSIGN:HR', 'value' : 90.0D, 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'male', 'race' : 'Caucasian', 'age': 26L, 'conceptCode' : 'CT:VSIGN:HR', 'value' : 88.0D, 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'male', 'race' : 'Latino', 'age': 24L, 'conceptCode' : 'CT:DEM:AGE', 'value' : 24.0D, 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'male', 'race' : 'Latino', 'age': 24L, 'conceptCode' : 'CT:VSIGN:HR', 'value' : 56.0D, 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'male', 'race' : 'Latino', 'age': 24L, 'conceptCode' : 'CT:VSIGN:HR', 'value' : 57.0D, 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20L, 'conceptCode' : 'CT:DEM:AGE', 'value' : 20.0D, 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20L, 'conceptCode' : 'CT:VSIGN:HR', 'value' : 66.0D, 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20L, 'conceptCode' : 'CT:VSIGN:HR', 'value' : 68.0D, 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20L, 'conceptCode' : 'CT:VSIGN:HR', 'value' : 56.0D, 'study' : 'CLINICAL_TRIAL'],
-            ['sex': 'female', 'race' : 'Caucasian', 'age': 20L, 'conceptCode' : 'CT:VSIGN:HR', 'value' : 88.0D, 'study' : 'CLINICAL_TRIAL']
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26L, 'conceptCode': 'CT:DEM:AGE', 'value': 26.0D, 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26L, 'conceptCode': 'CT:VSIGN:HR', 'value': 80.0D, 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26L, 'conceptCode': 'CT:VSIGN:HR', 'value': 90.0D, 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'male', 'race': 'Caucasian', 'age': 26L, 'conceptCode': 'CT:VSIGN:HR', 'value': 88.0D, 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'male', 'race': 'Latino', 'age': 24L, 'conceptCode': 'CT:DEM:AGE', 'value': 24.0D, 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'male', 'race': 'Latino', 'age': 24L, 'conceptCode': 'CT:VSIGN:HR', 'value': 56.0D, 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'male', 'race': 'Latino', 'age': 24L, 'conceptCode': 'CT:VSIGN:HR', 'value': 57.0D, 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20L, 'conceptCode': 'CT:DEM:AGE', 'value': 20.0D, 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20L, 'conceptCode': 'CT:VSIGN:HR', 'value': 66.0D, 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20L, 'conceptCode': 'CT:VSIGN:HR', 'value': 68.0D, 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20L, 'conceptCode': 'CT:VSIGN:HR', 'value': 56.0D, 'study': 'CLINICAL_TRIAL'],
+            ['sex': 'female', 'race': 'Caucasian', 'age': 20L, 'conceptCode': 'CT:VSIGN:HR', 'value': 88.0D, 'study': 'CLINICAL_TRIAL']
     ]
 
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/HighDimSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/HighDimSpec.groovy
@@ -1,12 +1,12 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.hypercube
 
+import annotations.RequiresStudy
 import base.RESTSpec
 import groovy.json.JsonBuilder
-import spock.lang.Ignore
-import spock.lang.IgnoreIf
-import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
 import static config.Config.*
 import static org.hamcrest.Matchers.is
 import static spock.util.matcher.HamcrestSupport.that
@@ -18,6 +18,7 @@ class HighDimSpec extends RESTSpec {
 
     //see CLINICAL_TRIAL_HIGHDIM, EHR_HIGHDIM and TUMOR_NORMAL_SAMPLES studies at the transmart-data/test_data/studies folder
 
+    @RequiresStudy(CLINICAL_TRIAL_HIGHDIM_ID)
     def "example call that shows all supported parameters"() {
         // any of supported constraints (but biomarker constraint) and their combinations.
         def assayConstraint = [
@@ -26,9 +27,9 @@ class HighDimSpec extends RESTSpec {
         ]
         // see transmart-core-api/src/main/groovy/org/transmartproject/core/dataquery/highdim/dataconstraints/DataConstraint.groovy
         def biomarkerConstraint = [
-                type: BiomarkerConstraint,
+                type         : BiomarkerConstraint,
                 biomarkerType: 'genes',
-                params: [
+                params       : [
                         names: ['TP53']
                 ]
         ]
@@ -36,13 +37,13 @@ class HighDimSpec extends RESTSpec {
         def projection = 'all_data'
 
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'mrna',
-                        constraint: new JsonBuilder(assayConstraint),
+                query     : [
+                        type                : 'mrna',
+                        constraint          : new JsonBuilder(assayConstraint),
                         biomarker_constraint: new JsonBuilder(biomarkerConstraint),
-                        projection: projection
+                        projection          : projection
                 ]
         ]
 
@@ -56,8 +57,8 @@ class HighDimSpec extends RESTSpec {
         assert responseData.cells.size() == biomarkers * assays * projections
 
         where:
-        acceptType | _
-        contentTypeForJSON | _
+        acceptType             | _
+        contentTypeForJSON     | _
         contentTypeForProtobuf | _
     }
 
@@ -66,28 +67,29 @@ class HighDimSpec extends RESTSpec {
      *      when: "I get highdim for this study"
      *      then: "BioMarker, Assay and Projection are encluded in the responce"
      */
-    def "highdim contains BioMarker, Assay and Projection"(){
+    @RequiresStudy(CLINICAL_TRIAL_HIGHDIM_ID)
+    def "highdim contains BioMarker, Assay and Projection"() {
         def assayConstraint = [
                 type: ConceptConstraint,
                 path: "\\Public Studies\\CLINICAL_TRIAL_HIGHDIM\\High Dimensional data\\Expression Lung\\"
         ]
         def biomarkerConstraint = [
-                type: BiomarkerConstraint,
+                type         : BiomarkerConstraint,
                 biomarkerType: 'genes',
-                params: [
+                params       : [
                         names: ['TP53']
                 ]
         ]
         def projection = 'all_data'
 
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
-                        constraint: new JsonBuilder(assayConstraint),
+                query     : [
+                        type                : 'autodetect',
+                        constraint          : new JsonBuilder(assayConstraint),
                         biomarker_constraint: new JsonBuilder(biomarkerConstraint),
-                        projection: projection
+                        projection          : projection
                 ]
         ]
 
@@ -102,15 +104,15 @@ class HighDimSpec extends RESTSpec {
             assert ['117_at', '1007_s_at'].contains(selector.select(it, 'biomarker', 'label', 'String'))
             assert selector.select(it, 'biomarker', 'biomarker', 'String') == null
 
-            assert [-6001,-6002,-6004,-6006,-6007,-6008].contains(selector.select(it, 'assay', 'id', 'Int') as int)
+            assert [-6001, -6002, -6004, -6006, -6007, -6008].contains(selector.select(it, 'assay', 'id', 'Int') as int)
             assert ['sample1', 'sample2', 'sample4', 'sample6', 'sample7', 'sample8'].contains(selector.select(it, 'assay', 'sampleCode', 'String'))
 
             assert ['probeName', 'trialName', 'logIntensity', 'organism', 'geneId', 'probeId', 'rawIntensity', 'assayId', 'zscore', 'geneSymbol'].contains(selector.select(it, 'projection', 'String'))
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -119,12 +121,13 @@ class HighDimSpec extends RESTSpec {
      *  when: "I get highdim for Expression Breast"
      *  then: "only data for Expression Breast is returned"
      */
-    def "highdim by ConceptConstraint"(){
+    @RequiresStudy(CLINICAL_TRIAL_HIGHDIM_ID)
+    def "highdim by ConceptConstraint"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
+                query     : [
+                        type      : 'autodetect',
                         constraint: new JsonBuilder([
                                 type: ConceptConstraint,
                                 path: "\\Public Studies\\CLINICAL_TRIAL_HIGHDIM\\High Dimensional data\\Expression Breast\\"
@@ -143,40 +146,40 @@ class HighDimSpec extends RESTSpec {
             assert ['117_at', '1007_s_at', '1053_at', '1053_s_at'].contains(selector.select(it, 'biomarker', 'label', 'String'))
             assert selector.select(it, 'biomarker', 'biomarker', 'String') == null
 
-            assert [-6003,-6005,-6009].contains(selector.select(it, 'assay', 'id', 'Int') as int)
+            assert [-6003, -6005, -6009].contains(selector.select(it, 'assay', 'id', 'Int') as int)
             assert ['sample3', 'sample5', 'sample9'].contains(selector.select(it, 'assay', 'sampleCode', 'String'))
 
             assert ['probeName', 'trialName', 'logIntensity', 'organism', 'geneId', 'probeId', 'rawIntensity', 'assayId', 'zscore', 'geneSymbol'].contains(selector.select(it, 'projection', 'String'))
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
-
 
     /**
      *  given: "study CLINICAL_TRIAL_HIGHDIM is loaded"
      *  when: "I get highdim for an imposable assayConstraint"
      *  then: "an empty message is returned"
      */
-    def "empty highdim"(){
+    @RequiresStudy(CLINICAL_TRIAL_HIGHDIM_ID)
+    def "empty highdim"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'mrna',
+                query     : [
+                        type      : 'mrna',
                         constraint: new JsonBuilder([
-                                type: Combination,
+                                type    : Combination,
                                 operator: AND,
-                                args: [
-                                        [type: FieldConstraint,
-                                         field: [dimension: 'patient', fieldName: 'age', type: NUMERIC ],
-                                         operator: EQUALS, value:20],
-                                        [type: FieldConstraint,
-                                         field: [dimension: 'patient', fieldName: 'age', type: NUMERIC ],
-                                         operator: EQUALS, value:30]
+                                args    : [
+                                        [type    : FieldConstraint,
+                                         field   : [dimension: 'patient', fieldName: 'age', type: NUMERIC],
+                                         operator: EQUALS, value: 20],
+                                        [type    : FieldConstraint,
+                                         field   : [dimension: 'patient', fieldName: 'age', type: NUMERIC],
+                                         operator: EQUALS, value: 30]
                                 ]
                         ])
                 ]
@@ -189,8 +192,8 @@ class HighDimSpec extends RESTSpec {
         assert responseData.cells == result
 
         where:
-        acceptType | newSelector | result
-        contentTypeForJSON | jsonSelector | []
+        acceptType             | newSelector      | result
+        contentTypeForJSON     | jsonSelector     | []
         contentTypeForProtobuf | protobufSelector | null
     }
 
@@ -199,26 +202,27 @@ class HighDimSpec extends RESTSpec {
      *  when: "I get highdim for different projections"
      *  then: "different fields are returned"
      */
+    @RequiresStudy(CLINICAL_TRIAL_HIGHDIM_ID)
     def "highdim projections"() {
         def assayConstraint = [
                 type: ConceptConstraint,
                 path: "\\Public Studies\\CLINICAL_TRIAL_HIGHDIM\\High Dimensional data\\Expression Lung\\"
         ]
         def requestZscore = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'mrna',
+                query     : [
+                        type      : 'mrna',
                         constraint: new JsonBuilder(assayConstraint),
                         projection: 'zscore'
                 ]
         ]
 
         def requestLog_intensity = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'mrna',
+                query     : [
+                        type      : 'mrna',
                         constraint: new JsonBuilder(assayConstraint),
                         projection: 'log_intensity'
                 ]
@@ -242,13 +246,13 @@ class HighDimSpec extends RESTSpec {
             valuesZscore.add(selectorZscore.select(it))
             valuesLog_intensity.add(selectorLog_intensity.select(it))
         }
-        valuesZscore.forEach{
+        valuesZscore.forEach {
             assert !valuesLog_intensity.contains(it)
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -258,24 +262,24 @@ class HighDimSpec extends RESTSpec {
      *  then: "logIntensity is returned"
      */
     //@IgnoreIf({SUPPRESS_KNOWN_BUGS}) //FIXME: TMPDEV-154 inconsistent use of projections
-    def "highdim projection"(){
+    def "highdim projection"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'mrna',
-                        constraint: new JsonBuilder([
+                query     : [
+                        type                : 'mrna',
+                        constraint          : new JsonBuilder([
                                 type: ConceptConstraint,
                                 path: "\\Public Studies\\CLINICAL_TRIAL_HIGHDIM\\High Dimensional data\\Expression Lung\\"
                         ]),
                         biomarker_constraint: new JsonBuilder([
-                                type: BiomarkerConstraint,
+                                type         : BiomarkerConstraint,
                                 biomarkerType: 'genes',
-                                params: [
+                                params       : [
                                         names: ['TP53']
                                 ]
                         ]),
-                        projection: 'log_intensity'
+                        projection          : 'log_intensity'
                 ]
         ]
 
@@ -288,8 +292,8 @@ class HighDimSpec extends RESTSpec {
         assert selector.cellCount == 12
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -298,29 +302,29 @@ class HighDimSpec extends RESTSpec {
      *  when: "I get highdim for EHR_HIGHDIM after 01-04-2016Z"
      *  then: "only data for Expression Breast is returned"
      */
-    @Requires({EHR_HIGHDIM_LOADED})
-    def "highdim by timeConstraint"(){
+    @RequiresStudy(EHR_HIGHDIM_ID)
+    def "highdim by timeConstraint"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'mrna',
+                query     : [
+                        type      : 'mrna',
                         constraint: new JsonBuilder([
-                                type: Combination,
+                                type    : Combination,
                                 operator: AND,
-                                args: [
+                                args    : [
                                         [
-                                            "type": ConceptConstraint,
-                                            "path": "\\Public Studies\\EHR_HIGHDIM\\High Dimensional data\\Expression Breast\\"
+                                                "type": ConceptConstraint,
+                                                "path": "\\Public Studies\\EHR_HIGHDIM\\High Dimensional data\\Expression Breast\\"
                                         ],
                                         [
-                                            "type": StudyNameConstraint,
-                                            "studyId": "EHR_HIGHDIM"
+                                                "type"   : StudyNameConstraint,
+                                                "studyId": "EHR_HIGHDIM"
                                         ],
-                                        [type: TimeConstraint,
-                                         field: [dimension: 'start time', fieldName: 'startDate', type: DATE ],
+                                        [type    : TimeConstraint,
+                                         field   : [dimension: 'start time', fieldName: 'startDate', type: DATE],
                                          operator: AFTER,
-                                         values: [toDateString("01-04-2016Z")]]
+                                         values  : [toDateString("01-04-2016Z")]]
                                 ]
                         ])
                 ]
@@ -344,8 +348,8 @@ class HighDimSpec extends RESTSpec {
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -354,26 +358,26 @@ class HighDimSpec extends RESTSpec {
      *  when: "I get highdim for TUMOR_NORMAL_SAMPLES with modifier Normal"
      *  then: "only data for modifier Normal is returned"
      */
-    @Requires({RNASEQ_TRANSCRIPT_ID})
-    def "highdim by modifier"(){
+    @RequiresStudy(RNASEQ_TRANSCRIPT_ID)
+    def "highdim by modifier"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'rnaseq_transcript',
+                query     : [
+                        type      : 'rnaseq_transcript',
                         constraint: new JsonBuilder([
-                                type: Combination,
+                                type    : Combination,
                                 operator: AND,
-                                args: [
+                                args    : [
                                         [
-                                            "type": ConceptConstraint,
-                                            "path": "\\Public Studies\\RNASEQ_TRANSCRIPT\\HD\\Breast\\"
+                                                "type": ConceptConstraint,
+                                                "path": "\\Public Studies\\RNASEQ_TRANSCRIPT\\HD\\Breast\\"
                                         ],
                                         [
-                                            "type": StudyNameConstraint,
-                                            "studyId": "RNASEQ_TRANSCRIPT"
+                                                "type"   : StudyNameConstraint,
+                                                "studyId": "RNASEQ_TRANSCRIPT"
                                         ],
-                                        [type: ModifierConstraint, path:"\\Public Studies\\RNASEQ_TRANSCRIPT\\Sample Type\\",
+                                        [type  : ModifierConstraint, path: "\\Public Studies\\RNASEQ_TRANSCRIPT\\Sample Type\\",
                                          values: [type: ValueConstraint, valueType: STRING, operator: EQUALS, value: "Tumor"]]
                                 ]
                         ])
@@ -391,7 +395,7 @@ class HighDimSpec extends RESTSpec {
             assert [null].contains(selector.select(it, 'biomarker', 'label', 'String'))
             assert ['tr1', 'tr2', 'tr3', 'tr4', null].contains(selector.select(it, 'biomarker', 'biomarker', 'String'))
 
-            assert [-643,-645].contains(selector.select(it, 'assay', 'id', 'Int') as int)
+            assert [-643, -645].contains(selector.select(it, 'assay', 'id', 'Int') as int)
             assert ['sample5', 'sample3'].contains(selector.select(it, 'assay', 'sampleCode', 'String'))
 
             assert ['readcount', 'platformMarkerType', 'normalizedReadcount', 'platformGenomeReleaseId', 'chromosome',
@@ -400,8 +404,8 @@ class HighDimSpec extends RESTSpec {
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -410,13 +414,13 @@ class HighDimSpec extends RESTSpec {
      *  when: "I get highdim for an invalid constraint"
      *  then: "an error is returned"
      */
-    @Requires({TUMOR_NORMAL_SAMPLES_LOADED})
-    def "highdim by invalid assay"(){
+    @RequiresStudy(TUMOR_NORMAL_SAMPLES_ID)
+    def "highdim by invalid assay"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'mrna',
+                query     : [
+                        type      : 'mrna',
                         constraint: new JsonBuilder([type: 'invalidConstraint'])
                 ],
                 statusCode: 400
@@ -431,8 +435,8 @@ class HighDimSpec extends RESTSpec {
         that responseData.message, is('Constraint not supported: invalidConstraint.')
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -441,13 +445,13 @@ class HighDimSpec extends RESTSpec {
      *  when: "I get highdim for a non-highdim concept"
      *  then: "an error is returned"
      */
-    @Requires({EHR_HIGHDIM_LOADED})
-    def "highdim by non-highdim concept"(){
+    @RequiresStudy(EHR_HIGHDIM_ID)
+    def "highdim by non-highdim concept"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'rnaseq_transcript',
+                query     : [
+                        type      : 'rnaseq_transcript',
                         constraint: new JsonBuilder([type: ConceptConstraint, path: "\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"])
                 ],
         ]
@@ -459,24 +463,25 @@ class HighDimSpec extends RESTSpec {
         assert responseData.cells == result
 
         where:
-        acceptType | newSelector | result
-        contentTypeForJSON | jsonSelector | []
+        acceptType             | newSelector      | result
+        contentTypeForJSON     | jsonSelector     | []
         contentTypeForProtobuf | protobufSelector | null
     }
 
-    def "multi patient bug"(){
+    @RequiresStudy(CLINICAL_TRIAL_HIGHDIM_ID)
+    def "multi patient bug"() {
 
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
-                        constraint: new JsonBuilder(["type":Combination, "operator":AND,
-                                                           "args": [
-                                                                   ["type": ConceptConstraint, "conceptCode": "CTHD:HD:EXPLUNG"],
-                                                                   ["type":FieldConstraint,
-                                                                    "field":["dimension":"trial visit","fieldName":"id","type":"ID"],"operator":"=","value":-402]
-                                                           ]
+                query     : [
+                        type      : 'autodetect',
+                        constraint: new JsonBuilder(["type": Combination, "operator": AND,
+                                                     "args": [
+                                                             ["type": ConceptConstraint, "conceptCode": "CTHD:HD:EXPLUNG"],
+                                                             ["type" : FieldConstraint,
+                                                              "field": ["dimension": "trial visit", "fieldName": "id", "type": "ID"], "operator": "=", "value": -402]
+                                                     ]
                         ])
                 ]
         ]
@@ -493,7 +498,7 @@ class HighDimSpec extends RESTSpec {
         assert listSexCd.containsAll("Female", "Male")
 
         where:
-        acceptType | newSelector
+        acceptType         | newSelector
         contentTypeForJSON | jsonSelector
 
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/InvalidConstraintSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/InvalidConstraintSpec.groovy
@@ -3,21 +3,21 @@ package tests.rest.v2.hypercube
 
 import base.RESTSpec
 
-import static config.Config.*
-import static org.hamcrest.Matchers.is
-import static spock.util.matcher.HamcrestSupport.that
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
+import static config.Config.PATH_OBSERVATIONS
 import static tests.rest.v2.Operator.*
 import static tests.rest.v2.ValueType.*
 import static tests.rest.v2.constraints.*
 
-class InvalidConstraintSpec extends RESTSpec{
+class InvalidConstraintSpec extends RESTSpec {
 
-    def "ModifierConstraint.class"(){
+    def "ModifierConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: ModifierConstraint, path: badValue,
+                query     : toQuery([
+                        type  : ModifierConstraint, path: badValue,
                         values: [type: ValueConstraint, valueType: STRING, operator: EQUALS, value: "Tumor"]
                 ]),
                 statusCode: 400
@@ -31,10 +31,10 @@ class InvalidConstraintSpec extends RESTSpec{
 
         when:
         request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: ModifierConstraint, modifierCode: badValue,
+                query     : toQuery([
+                        type  : ModifierConstraint, modifierCode: badValue,
                         values: [type: ValueConstraint, valueType: STRING, operator: EQUALS, value: "Tumor"]
                 ]),
                 statusCode: 400
@@ -46,26 +46,26 @@ class InvalidConstraintSpec extends RESTSpec{
         assert responseData.errors.size() > 0
 
         where:
-        acceptType | badValue
-        contentTypeForJSON | null
-        contentTypeForJSON | ""
-        contentTypeForJSON | "  "
+        acceptType             | badValue
+        contentTypeForJSON     | null
+        contentTypeForJSON     | ""
+        contentTypeForJSON     | "  "
         contentTypeForProtobuf | null
         contentTypeForProtobuf | ""
         contentTypeForProtobuf | "  "
 
     }
 
-    def "FieldConstraint.class"(){
+    def "FieldConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: FieldConstraint,
-                                field: [dimension: 'patient',
-                                        fieldName: 'age',
-                                        type: NUMERIC ],
-                                operator: EQUALS,
-                                value:badValue]),
+                query     : toQuery([type    : FieldConstraint,
+                                     field   : [dimension: 'patient',
+                                                fieldName: 'age',
+                                                type     : NUMERIC],
+                                     operator: EQUALS,
+                                     value   : badValue]),
                 statusCode: 400
         ]
 
@@ -76,20 +76,20 @@ class InvalidConstraintSpec extends RESTSpec{
         assert responseData.errors.size() > 0
 
         where:
-        acceptType | badValue
-        contentTypeForJSON | null
-        contentTypeForJSON | ""
-        contentTypeForJSON | "  "
+        acceptType             | badValue
+        contentTypeForJSON     | null
+        contentTypeForJSON     | ""
+        contentTypeForJSON     | "  "
         contentTypeForProtobuf | null
         contentTypeForProtobuf | ""
         contentTypeForProtobuf | "  "
     }
 
-    def "ValueConstraint.class"(){
+    def "ValueConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ValueConstraint, valueType: NUMERIC, operator: GREATER_THAN, value:badValue]),
+                query     : toQuery([type: ValueConstraint, valueType: NUMERIC, operator: GREATER_THAN, value: badValue]),
                 statusCode: 400
         ]
 
@@ -100,23 +100,23 @@ class InvalidConstraintSpec extends RESTSpec{
         assert responseData.errors.size() > 0
 
         where:
-        acceptType | badValue
-        contentTypeForJSON | null
-        contentTypeForJSON | ""
-        contentTypeForJSON | "  "
+        acceptType             | badValue
+        contentTypeForJSON     | null
+        contentTypeForJSON     | ""
+        contentTypeForJSON     | "  "
         contentTypeForProtobuf | null
         contentTypeForProtobuf | ""
         contentTypeForProtobuf | "  "
     }
 
-    def "TimeConstraint.class"(){
+    def "TimeConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: TimeConstraint,
-                                field: [dimension: 'start time', fieldName: 'startDate', type: DATE ],
-                                operator: AFTER,
-                                values: [badValue]]),
+                query     : toQuery([type    : TimeConstraint,
+                                     field   : [dimension: 'start time', fieldName: 'startDate', type: DATE],
+                                     operator: AFTER,
+                                     values  : [badValue]]),
                 statusCode: status
         ]
 
@@ -127,22 +127,22 @@ class InvalidConstraintSpec extends RESTSpec{
         assert responseData.httpStatus == status
 
         where:
-        acceptType | badValue | status
-        contentTypeForJSON | null | 500
-        contentTypeForJSON | "" | 500
-        contentTypeForJSON | "  " | 400
-        contentTypeForProtobuf | null | 500
-        contentTypeForProtobuf | "" | 500
-        contentTypeForProtobuf | "  " | 400
+        acceptType             | badValue | status
+        contentTypeForJSON     | null     | 500
+        contentTypeForJSON     | ""       | 500
+        contentTypeForJSON     | "  "     | 400
+        contentTypeForProtobuf | null     | 500
+        contentTypeForProtobuf | ""       | 500
+        contentTypeForProtobuf | "  "     | 400
     }
 
-    def "Negation.class"(){
+    def "Negation.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
+                query     : toQuery([
                         type: Negation,
-                        arg: badValue
+                        arg : badValue
                 ]),
                 statusCode: 400
         ]
@@ -153,23 +153,23 @@ class InvalidConstraintSpec extends RESTSpec{
         then:
         assert responseData.httpStatus == 400
         where:
-        acceptType | badValue
-        contentTypeForJSON | null
-        contentTypeForJSON | ""
-        contentTypeForJSON | "  "
+        acceptType             | badValue
+        contentTypeForJSON     | null
+        contentTypeForJSON     | ""
+        contentTypeForJSON     | "  "
         contentTypeForProtobuf | null
         contentTypeForProtobuf | ""
         contentTypeForProtobuf | "  "
     }
 
-    def "Combination.class"(){
+    def "Combination.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
+                        args    : [
                                 badValue,
                                 badValue
                         ]
@@ -184,22 +184,22 @@ class InvalidConstraintSpec extends RESTSpec{
         assert responseData.httpStatus == 400
 
         where:
-        acceptType | badValue
-        contentTypeForJSON | null
-        contentTypeForJSON | ""
-        contentTypeForJSON | "  "
+        acceptType             | badValue
+        contentTypeForJSON     | null
+        contentTypeForJSON     | ""
+        contentTypeForJSON     | "  "
         contentTypeForProtobuf | null
         contentTypeForProtobuf | ""
         contentTypeForProtobuf | "  "
     }
 
-    def "TemporalConstraint.class"(){
+    def "TemporalConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: TemporalConstraint,
-                        operator: AFTER,
+                query     : toQuery([
+                        type           : TemporalConstraint,
+                        operator       : AFTER,
                         eventConstraint: [
                                 badValue
                         ]
@@ -214,20 +214,20 @@ class InvalidConstraintSpec extends RESTSpec{
         assert responseData.httpStatus == 400
 
         where:
-        acceptType | badValue
-        contentTypeForJSON | null
-        contentTypeForJSON | ""
-        contentTypeForJSON | "  "
+        acceptType             | badValue
+        contentTypeForJSON     | null
+        contentTypeForJSON     | ""
+        contentTypeForJSON     | "  "
         contentTypeForProtobuf | null
         contentTypeForProtobuf | ""
         contentTypeForProtobuf | "  "
     }
 
-    def "ConceptConstraint.class"(){
+    def "ConceptConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ConceptConstraint, path: badValue]),
+                query     : toQuery([type: ConceptConstraint, path: badValue]),
                 statusCode: 400
         ]
 
@@ -238,20 +238,20 @@ class InvalidConstraintSpec extends RESTSpec{
         assert responseData.errors.size() > 0
 
         where:
-        acceptType | badValue
-        contentTypeForJSON | null
-        contentTypeForJSON | ""
-        contentTypeForJSON | "  "
+        acceptType             | badValue
+        contentTypeForJSON     | null
+        contentTypeForJSON     | ""
+        contentTypeForJSON     | "  "
         contentTypeForProtobuf | null
         contentTypeForProtobuf | ""
         contentTypeForProtobuf | "  "
     }
 
-    def "StudyConstraint.class"(){
+    def "StudyConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: StudyNameConstraint, studyId: badValue]),
+                query     : toQuery([type: StudyNameConstraint, studyId: badValue]),
                 statusCode: 400
         ]
 
@@ -262,26 +262,26 @@ class InvalidConstraintSpec extends RESTSpec{
         assert responseData.errors.size() > 0
 
         where:
-        acceptType | badValue
-        contentTypeForJSON | null
-        contentTypeForJSON | ""
-        contentTypeForJSON | "  "
+        acceptType             | badValue
+        contentTypeForJSON     | null
+        contentTypeForJSON     | ""
+        contentTypeForJSON     | "  "
         contentTypeForProtobuf | null
         contentTypeForProtobuf | ""
         contentTypeForProtobuf | "  "
     }
 
-    def "NullConstraint.class"(){
+    def "NullConstraint.class"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: NullConstraint,
+                query     : toQuery([
+                        type : NullConstraint,
                         field: badValue
                 ]),
                 statusCode: 400
         ]
-        
+
         when:
         def responseData = get(request)
 
@@ -289,10 +289,10 @@ class InvalidConstraintSpec extends RESTSpec{
         assert responseData.httpStatus == 400
 
         where:
-        acceptType | badValue
-        contentTypeForJSON | null
-        contentTypeForJSON | ""
-        contentTypeForJSON | "  "
+        acceptType             | badValue
+        contentTypeForJSON     | null
+        contentTypeForJSON     | ""
+        contentTypeForJSON     | "  "
         contentTypeForProtobuf | null
         contentTypeForProtobuf | ""
         contentTypeForProtobuf | "  "

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/ModifiersSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/ModifiersSpec.groovy
@@ -1,15 +1,19 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.hypercube
 
+import annotations.RequiresStudy
 import base.RESTSpec
 import tests.rest.v2.constraints
 
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
 import static config.Config.PATH_OBSERVATIONS
 import static config.Config.TUMOR_NORMAL_SAMPLES_ID
 import static tests.rest.v2.Operator.OR
 import static tests.rest.v2.constraints.Combination
 import static tests.rest.v2.constraints.ConceptConstraint
 
+@RequiresStudy(TUMOR_NORMAL_SAMPLES_ID)
 class ModifiersSpec extends RESTSpec {
 
     /**
@@ -20,9 +24,9 @@ class ModifiersSpec extends RESTSpec {
     def "get modifiers"() {
         given: "study TUMOR_NORMAL_SAMPLES is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: constraints.StudyNameConstraint, studyId: TUMOR_NORMAL_SAMPLES_ID])
+                query     : toQuery([type: constraints.StudyNameConstraint, studyId: TUMOR_NORMAL_SAMPLES_ID])
         ]
 
         when: "I get all observations"
@@ -40,8 +44,8 @@ class ModifiersSpec extends RESTSpec {
         assert modifierDimension == [null, 'Tumor', 'Normal'] as HashSet
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -53,12 +57,12 @@ class ModifiersSpec extends RESTSpec {
     def "get modifiers by concept"() {
         given: "study TUMOR_NORMAL_SAMPLES is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: OR,
-                        args: [
+                        args    : [
                                 [type: ConceptConstraint, path: "\\Public Studies\\TUMOR_NORMAL_SAMPLES\\Lab\\Cell Count\\"],
                                 [type: ConceptConstraint, path: "\\Public Studies\\TUMOR_NORMAL_SAMPLES\\HD\\Breast\\"]
                         ]
@@ -81,8 +85,8 @@ class ModifiersSpec extends RESTSpec {
         assert modifierDimension.containsAll('Tumor', 'Normal')
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/MultipleObservationsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/MultipleObservationsSpec.groovy
@@ -1,30 +1,33 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.hypercube
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
-import static config.Config.*
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
+import static config.Config.EHR_ID
+import static config.Config.PATH_OBSERVATIONS
 import static tests.rest.v2.Operator.AND
 import static tests.rest.v2.constraints.*
 
-@Requires({EHR_LOADED})
-class MultipleObservationsSpec extends RESTSpec{
+@RequiresStudy(EHR_ID)
+class MultipleObservationsSpec extends RESTSpec {
 
     /**
      *  Given: "ClinicalTrial is loaded"
      *  When: "I get observations for patient 1 for concept HEARTRATE"
      *  Then: "3 observations are returned"
      */
-    def "Multiple observations are possible per combination of concept and patient"(){
+    def "Multiple observations are possible per combination of concept and patient"() {
         given: "Ward-ClinicalTrial is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
+                        args    : [
                                 [type: PatientSetConstraint, patientIds: -62],
                                 [type: ConceptConstraint, path: "\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"]
                         ]
@@ -44,8 +47,8 @@ class MultipleObservationsSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -54,12 +57,12 @@ class MultipleObservationsSpec extends RESTSpec{
      *  when: "I get all observations of that studie"
      *  then: "7 observations have a valid startDate as JSON date
      */
-    def "Start time of observations are exposed through REST API"(){
+    def "Start time of observations are exposed through REST API"() {
         given: "EHR is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: StudyNameConstraint, studyId: EHR_ID])
+                query     : toQuery([type: StudyNameConstraint, studyId: EHR_ID])
         ]
 
         when: "I get all observations of that studie"
@@ -74,7 +77,7 @@ class MultipleObservationsSpec extends RESTSpec{
 
         int validStartDate = 0
         (0..<selector.cellCount).each {
-            if (selector.select(it, 'start time', null, 'Timestamp') != null){
+            if (selector.select(it, 'start time', null, 'Timestamp') != null) {
                 validStartDate++
                 assertion(selector, it)
             }
@@ -84,9 +87,9 @@ class MultipleObservationsSpec extends RESTSpec{
         assert validStartDate == 7
 
         where:
-        acceptType | newSelector | assertion
-        contentTypeForJSON | jsonSelector | {it, index -> assert (it.select(index, 'start time', null, 'Timestamp') as Date) instanceof Date}
-        contentTypeForProtobuf | protobufSelector | {it, index -> assert it.select(index, 'start time', null, 'Timestamp') instanceof Number}
+        acceptType             | newSelector      | assertion
+        contentTypeForJSON     | jsonSelector     | { it, index -> assert (it.select(index, 'start time', null, 'Timestamp') as Date) instanceof Date }
+        contentTypeForProtobuf | protobufSelector | { it, index -> assert it.select(index, 'start time', null, 'Timestamp') instanceof Number }
     }
 
     /**
@@ -94,12 +97,12 @@ class MultipleObservationsSpec extends RESTSpec{
      *  when: "I get all observations of that studie"
      *  then: "4 observations have a nonNUll endDate as JSON date
      */
-    def "end time of observations are exposed through REST API"(){
+    def "end time of observations are exposed through REST API"() {
         given: "EHR is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: StudyNameConstraint, studyId: EHR_ID])
+                query     : toQuery([type: StudyNameConstraint, studyId: EHR_ID])
         ]
 
         when: "I get all observations of that studie"
@@ -110,7 +113,7 @@ class MultipleObservationsSpec extends RESTSpec{
 
         int nonNUllEndDate = 0
         (0..<selector.cellCount).each {
-            if (selector.select(it, 'end time', null, 'Timestamp') != null){
+            if (selector.select(it, 'end time', null, 'Timestamp') != null) {
                 nonNUllEndDate++
                 assertion(selector, it)
             }
@@ -119,9 +122,9 @@ class MultipleObservationsSpec extends RESTSpec{
         assert nonNUllEndDate == 4
 
         where:
-        acceptType | newSelector | assertion
-        contentTypeForJSON | jsonSelector | {it, index -> assert (it.select(index, 'start time', null, 'Timestamp') as Date) instanceof Date}
-        contentTypeForProtobuf | protobufSelector | {it, index -> assert it.select(index, 'start time', null, 'Timestamp') instanceof Number}
+        acceptType             | newSelector      | assertion
+        contentTypeForJSON     | jsonSelector     | { it, index -> assert (it.select(index, 'start time', null, 'Timestamp') as Date) instanceof Date }
+        contentTypeForProtobuf | protobufSelector | { it, index -> assert it.select(index, 'start time', null, 'Timestamp') instanceof Number }
     }
 
     /**
@@ -131,16 +134,16 @@ class MultipleObservationsSpec extends RESTSpec{
      *
      * @return
      */
-    def "get MultipleObservations per user"(){
+    def "get MultipleObservations per user"() {
         given: "study EHR is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
-                                [type: PatientSetConstraint, patientIds: [-62,-42]],
+                        args    : [
+                                [type: PatientSetConstraint, patientIds: [-62, -42]],
                                 [type: ConceptConstraint, path: "\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"]
                         ]
                 ])
@@ -160,8 +163,8 @@ class MultipleObservationsSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/PrettyJsonSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/PrettyJsonSpec.groovy
@@ -1,14 +1,17 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.hypercube
 
+import annotations.RequiresStudy
 import base.RESTSpec
 import spock.lang.Ignore
 
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.EHR_ID
 import static config.Config.PATH_PATIENTS
 import static tests.rest.v2.constraints.StudyNameConstraint
 
-class PrettyJsonSpec extends RESTSpec{
+@RequiresStudy(EHR_ID)
+class PrettyJsonSpec extends RESTSpec {
 
     /**
      * given: 'we get Json'
@@ -16,14 +19,14 @@ class PrettyJsonSpec extends RESTSpec{
      * then: 'he scores at least 8'
      */
     @Ignore
-    def "Is Json pretty enough?"(){
+    def "Is Json pretty enough?"() {
         int index = new Random().nextInt(3)
 
         given: 'we get json'
         def Json = get([
-                path: PATH_PATIENTS,
+                path      : PATH_PATIENTS,
                 acceptType: contentTypeForJSON,
-                query: toQuery([type: StudyNameConstraint, studyId: EHR_ID])
+                query     : toQuery([type: StudyNameConstraint, studyId: EHR_ID])
         ]).patients[index]
 
         when: 'we rate his prettynis'
@@ -32,15 +35,15 @@ class PrettyJsonSpec extends RESTSpec{
         if (Json.deathDate == null) score += 3
         if (Json.age < 40) score++
         if (Json.age > 25) score++
-        assert Json.age > 18 : "Json needs to grow up, stop looking at him like that!"
+        assert Json.age > 18: "Json needs to grow up, stop looking at him like that!"
         if (Json.maritalStatus == null) score++
         if (Json.sex == 'MALE') score++
-        if (Json.sex == 'YES') score +=3
+        if (Json.sex == 'YES') score += 3
         if (Json.race == 'Latino') score++
 
         then: 'he scores at least 8'
         println(Json)
-        assert score >= 8 : "score is ${score}, sorry Json is not pretty enough."
+        assert score >= 8: "score is ${score}, sorry Json is not pretty enough."
     }
 
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/RelativeTimepointsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/RelativeTimepointsSpec.groovy
@@ -1,9 +1,11 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.hypercube
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
 import static config.Config.*
 import static tests.rest.v2.Operator.*
 import static tests.rest.v2.ValueType.NUMERIC
@@ -24,13 +26,13 @@ class RelativeTimepointsSpec extends RESTSpec {
      *  when: "I get observations from that study related to Baseline"
      *  then: "4 observations are returned"
      */
-    @Requires({ CLINICAL_TRIAL_LOADED })
+    @RequiresStudy(CLINICAL_TRIAL_ID)
     def "multiple observations to a relative timepoint"() {
         given: "study CLINICAL_TRIAL is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
+                query     : toQuery([
                         type    : Combination,
                         operator: AND,
                         args    : [
@@ -56,8 +58,8 @@ class RelativeTimepointsSpec extends RESTSpec {
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -67,13 +69,13 @@ class RelativeTimepointsSpec extends RESTSpec {
      *  and: "I get observations related to 7 days"
      *  then: "both sets of observations are the same"
      */
-    @Requires({ CLINICAL_TRIAL_LOADED })
+    @RequiresStudy(CLINICAL_TRIAL_ID)
     def "label and relative time is te same"() {
         given: "study CLINICAL_TRIAL is loaded"
         def request1week = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
+                query     : toQuery([
                         type    : Combination,
                         operator: AND,
                         args    : [
@@ -89,9 +91,9 @@ class RelativeTimepointsSpec extends RESTSpec {
         ]
 
         def request7days = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
+                query     : toQuery([
                         type    : Combination,
                         operator: AND,
                         args    : [
@@ -126,8 +128,8 @@ class RelativeTimepointsSpec extends RESTSpec {
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -136,13 +138,13 @@ class RelativeTimepointsSpec extends RESTSpec {
      *  when: "I get observations within that study related to General"
      *  then: "multiple concepts are returned"
      */
-    @Requires({ EHR_LOADED })
+    @RequiresStudy(EHR_ID)
     def "multiple concepts to the same relative timepoint within the same study"() {
         given: "study EHR is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
+                query     : toQuery([
                         type    : Combination,
                         operator: AND,
                         args    : [
@@ -169,8 +171,8 @@ class RelativeTimepointsSpec extends RESTSpec {
         assert concepts.containsAll('EHR:DEM:AGE', 'EHR:VSIGN:HR')
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -179,18 +181,18 @@ class RelativeTimepointsSpec extends RESTSpec {
      *  when: "I get observations related to the General relative time label"
      *  then: "multiple concepts from both EHR and CLINICAL_TRIAL are returned"
      */
-    @Requires({ EHR_LOADED && CLINICAL_TRIAL_LOADED })
+    @RequiresStudy([CLINICAL_TRIAL_ID, EHR_ID])
     def "multiple concepts to the same relative timepoint within several studies"() {
         given: "studies EHR and CLINICAL_TRIAL are loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type    : FieldConstraint,
-                                field   : [dimension: 'trial visit',
-                                           fieldName: 'relTimeLabel',
-                                           type     : STRING],
-                                operator: EQUALS,
-                                value   : 'General'])
+                query     : toQuery([type    : FieldConstraint,
+                                     field   : [dimension: 'trial visit',
+                                                fieldName: 'relTimeLabel',
+                                                type     : STRING],
+                                     operator: EQUALS,
+                                     value   : 'General'])
         ]
 
         when: "I get observations related to the General relative time label"
@@ -205,8 +207,8 @@ class RelativeTimepointsSpec extends RESTSpec {
         assert concepts.containsAll('EHR:DEM:AGE', 'EHR:VSIGN:HR', 'CT:DEM:AGE')
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -216,13 +218,13 @@ class RelativeTimepointsSpec extends RESTSpec {
      *  and: "I get observations related to GREATER_THEN the second to last week"
      *  then: "both sets of observations are the same"
      */
-    @Requires({ CLINICAL_TRIAL_LOADED })
+    @RequiresStudy(CLINICAL_TRIAL_ID)
     def "relative timescale compared to other relative timepoints"() {
         given: "study CLINICAL_TRIAL is loaded"
         def request3week = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
+                query     : toQuery([
                         type    : Combination,
                         operator: AND,
                         args    : [
@@ -238,9 +240,9 @@ class RelativeTimepointsSpec extends RESTSpec {
         ]
 
         def request7days = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
+                query     : toQuery([
                         type    : Combination,
                         operator: AND,
                         args    : [
@@ -275,8 +277,8 @@ class RelativeTimepointsSpec extends RESTSpec {
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/SamplesSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/SamplesSpec.groovy
@@ -1,11 +1,13 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.hypercube
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
 import static config.Config.PATH_OBSERVATIONS
-import static config.Config.TUMOR_NORMAL_SAMPLES_LOADED
+import static config.Config.TUMOR_NORMAL_SAMPLES_ID
 import static tests.rest.v2.Operator.EQUALS
 import static tests.rest.v2.ValueType.STRING
 import static tests.rest.v2.constraints.ModifierConstraint
@@ -14,21 +16,21 @@ import static tests.rest.v2.constraints.ValueConstraint
 /**
  *   TMPREQ-12 Support storing and fetching multiple samples.
  */
-class SamplesSpec extends RESTSpec{
+@RequiresStudy(TUMOR_NORMAL_SAMPLES_ID)
+class SamplesSpec extends RESTSpec {
 
     /**
      *  given: "study TUMOR_NORMAL_SAMPLES is loaded"
      *  when: "I get all observations related to a modifier "Sample type" with value "Tumor""
      *  then: "8 observations are returned, with concept Cell Count, Breast, Lung"
      */
-    @Requires({TUMOR_NORMAL_SAMPLES_LOADED})
-    def "get observations related to a modifier"(){
+    def "get observations related to a modifier"() {
         given: "study TUMOR_NORMAL_SAMPLES is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: ModifierConstraint, path:"\\Public Studies\\TUMOR_NORMAL_SAMPLES\\Sample Type\\",
+                query     : toQuery([
+                        type  : ModifierConstraint, path: "\\Public Studies\\TUMOR_NORMAL_SAMPLES\\Sample Type\\",
                         values: [type: ValueConstraint, valueType: STRING, operator: EQUALS, value: "Tumor"]
                 ])
         ]
@@ -45,8 +47,8 @@ class SamplesSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -55,14 +57,13 @@ class SamplesSpec extends RESTSpec{
      *  when: "I get all observations related to a modifier "Sample type" without value"
      *  then: "16 observations are returned, with concept Cell Count, Breast, Lung"
      */
-    @Requires({TUMOR_NORMAL_SAMPLES_LOADED})
-    def "get observations related to a modifier without value"(){
+    def "get observations related to a modifier without value"() {
         given: "study TUMOR_NORMAL_SAMPLES is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: ModifierConstraint, path:"\\Public Studies\\TUMOR_NORMAL_SAMPLES\\Sample Type\\"
+                query     : toQuery([
+                        type: ModifierConstraint, path: "\\Public Studies\\TUMOR_NORMAL_SAMPLES\\Sample Type\\"
                 ])
         ]
 
@@ -78,8 +79,8 @@ class SamplesSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -88,14 +89,13 @@ class SamplesSpec extends RESTSpec{
      *  when: "I get all observations related to a modifier "does not exist"
      *  then: "0 observations are returned"
      */
-    @Requires({TUMOR_NORMAL_SAMPLES_LOADED})
-    def "get observations related to a modifier that does not exist"(){
+    def "get observations related to a modifier that does not exist"() {
         given: "study TUMOR_NORMAL_SAMPLES is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: ModifierConstraint, path:"\\Public Studies\\TUMOR_NORMAL_SAMPLES\\does not exist\\"
+                query     : toQuery([
+                        type: ModifierConstraint, path: "\\Public Studies\\TUMOR_NORMAL_SAMPLES\\does not exist\\"
                 ])
         ]
 
@@ -106,8 +106,8 @@ class SamplesSpec extends RESTSpec{
         assert responseData.cells == []
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/SharedConceptsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/SharedConceptsSpec.groovy
@@ -1,9 +1,11 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.hypercube
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
 import static config.Config.*
 import static tests.rest.v2.Operator.AND
 import static tests.rest.v2.Operator.OR
@@ -12,7 +14,7 @@ import static tests.rest.v2.constraints.*
 /**
  *  TMPREQ-5 Building a generic concept tree across studies
  */
-@Requires({SHARED_CONCEPTS_LOADED})
+@RequiresStudy([SHARED_CONCEPTS_A_ID, SHARED_CONCEPTS_B_ID])
 class SharedConceptsSpec extends RESTSpec {
 
     /**
@@ -20,12 +22,12 @@ class SharedConceptsSpec extends RESTSpec {
      *  when: "I get observaties using this shared Consept id"
      *  then: "observations are returned from both Studies"
      */
-    def "get shared concept multi study"(){
+    def "get shared concept multi study"() {
         given: "studies STUDIENAME and STUDIENAME are loaded and both use shared Consept ids"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"])
         ]
 
         when: "I get observaties using this shared Consept id"
@@ -40,8 +42,8 @@ class SharedConceptsSpec extends RESTSpec {
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -50,15 +52,15 @@ class SharedConceptsSpec extends RESTSpec {
      *  when: "I get observaties of one study using this shared Consept id"
      *  then: "observations are returned from only that Studies"
      */
-    def "get shared concept single study"(){
+    def "get shared concept single study"() {
         given: "studies SHARED_CONCEPTS_A and SHARED_CONCEPTS_B are loaded and both use shared Consept ids"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
+                        args    : [
                                 [type: StudyNameConstraint, studyId: SHARED_CONCEPTS_A_ID],
                                 [type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"]
                         ]
@@ -77,8 +79,8 @@ class SharedConceptsSpec extends RESTSpec {
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -87,13 +89,13 @@ class SharedConceptsSpec extends RESTSpec {
      *  when: "I get observaties using a shared Consept id"
      *  then: "observations are returned from both public Studies but not the restricted study"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED})
-    def "get shared concept restricted"(){
+    @RequiresStudy(SHARED_CONCEPTS_RESTRICTED_ID)
+    def "get shared concept restricted"() {
         given: "studies STUDIENAME, STUDIENAME and STUDIENAME_RESTRICTED are loaded and all use shared Consept ids"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"])
         ]
 
         when: "I get observaties using this shared Consept id"
@@ -109,8 +111,8 @@ class SharedConceptsSpec extends RESTSpec {
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -119,14 +121,14 @@ class SharedConceptsSpec extends RESTSpec {
      *  when: "I get observaties using a shared Consept id"
      *  then: "observations are returned from both public Studies but not the restricted study"
      */
-    @Requires({SHARED_CONCEPTS_RESTRICTED_LOADED})
-    def "get shared concept unrestricted"(){
+    @RequiresStudy(SHARED_CONCEPTS_RESTRICTED_ID)
+    def "get shared concept unrestricted"() {
         given: "studies STUDIENAME, STUDIENAME and STUDIENAME_RESTRICTED are loaded and all use shared Consept ids"
         setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"])
+                query     : toQuery([type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"])
         ]
 
         when: "I get observaties using this shared Consept id"
@@ -141,28 +143,29 @@ class SharedConceptsSpec extends RESTSpec {
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
-    def "limit shared concept"(){
-        setUser(ADMIN_USERNAME,ADMIN_PASSWORD)
+    @RequiresStudy(SHARED_CONCEPTS_RESTRICTED_ID)
+    def "limit shared concept"() {
+        setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def heartRate = [type: ConceptConstraint, path: "\\Vital Signs\\Heart Rate\\"]
 
         def studiesOR = [
-                type: Combination,
+                type    : Combination,
                 operator: OR,
-                args: [
+                args    : [
                         [type: StudyNameConstraint, studyId: SHARED_CONCEPTS_A_ID],
                         [type: StudyNameConstraint, studyId: SHARED_CONCEPTS_B_ID]
                 ]
         ]
 
         def constaint = [
-                type: Combination,
+                type    : Combination,
                 operator: AND,
-                args: [
+                args    : [
                         studiesOR,
                         heartRate
                 ]
@@ -180,8 +183,8 @@ class SharedConceptsSpec extends RESTSpec {
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/TimeConstraintSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/TimeConstraintSpec.groovy
@@ -1,10 +1,13 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.hypercube
 
+import annotations.RequiresStudy
 import base.RESTSpec
-import spock.lang.Requires
 
-import static config.Config.*
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
+import static config.Config.EHR_ID
+import static config.Config.PATH_OBSERVATIONS
 import static tests.rest.v2.Operator.*
 import static tests.rest.v2.constraints.*
 
@@ -14,28 +17,28 @@ import static tests.rest.v2.constraints.*
  *      start time
  *      end time
  */
-class TimeConstraintSpec extends RESTSpec{
+@RequiresStudy(EHR_ID)
+class TimeConstraintSpec extends RESTSpec {
 
     /**
      *  given: "Ward-EHR is loaded"
      *  when: "I query observations in this study with startDate after 01-01-2016"
      *  then: "6 observations are returned"
      */
-    @Requires({EHR_LOADED})
-    def "query observations based on time constraint after startDate"(){
+    def "query observations based on time constraint after startDate"() {
         given: "Ward-EHR is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
+                        args    : [
                                 [type: StudyNameConstraint, studyId: EHR_ID],
-                                [type: TimeConstraint,
-                                 field: [dimension: 'start time', fieldName: 'startDate', type: 'DATE' ],
+                                [type    : TimeConstraint,
+                                 field   : [dimension: 'start time', fieldName: 'startDate', type: 'DATE'],
                                  operator: AFTER,
-                                 values: [toDateString("01-01-2016Z")]]
+                                 values  : [toDateString("01-01-2016Z")]]
                         ]
                 ])
         ]
@@ -52,8 +55,8 @@ class TimeConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -62,23 +65,22 @@ class TimeConstraintSpec extends RESTSpec{
      *  when: "I query observations in this study with startDate between 29-3-2016 10:00:00 and 29-3-2016 10:11:00"
      *  then: "2 observations are returned"
      */
-    @Requires({EHR_LOADED})
-    def "query observations based on time constraint between startDates"(){
+    def "query observations based on time constraint between startDates"() {
         given: "Ward-EHR is loaded"
         def date1 = toDateString("29-3-2016 10:00:00Z", "dd-MM-yyyy HH:mm:ssX")
         def date2 = toDateString("29-3-2016 10:11:00Z", "dd-MM-yyyy HH:mm:ssX")
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
+                        args    : [
                                 [type: StudyNameConstraint, studyId: EHR_ID],
-                                [type: TimeConstraint,
-                                 field: [dimension: 'start time', fieldName: 'startDate', type: 'DATE' ],
+                                [type    : TimeConstraint,
+                                 field   : [dimension: 'start time', fieldName: 'startDate', type: 'DATE'],
                                  operator: BETWEEN,
-                                 values: [date1, date2]]
+                                 values  : [date1, date2]]
                         ]
                 ])
         ]
@@ -95,8 +97,8 @@ class TimeConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -105,21 +107,20 @@ class TimeConstraintSpec extends RESTSpec{
      *  when: "I query observations in this study with startDate before 01-01-2016"
      *  then: "1 observation is returned"
      */
-    @Requires({EHR_LOADED})
-    def "query observations based on time constraint before startDate"(){
+    def "query observations based on time constraint before startDate"() {
         given: "Ward-EHR is loaded"
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
+                        args    : [
                                 [type: StudyNameConstraint, studyId: EHR_ID],
-                                [type: TimeConstraint,
-                                 field: [dimension: 'start time', fieldName: 'startDate', type: 'DATE' ],
+                                [type    : TimeConstraint,
+                                 field   : [dimension: 'start time', fieldName: 'startDate', type: 'DATE'],
                                  operator: BEFORE,
-                                 values: toDateString("01-01-2016Z")]
+                                 values  : toDateString("01-01-2016Z")]
                         ]
                 ])
         ]
@@ -135,8 +136,8 @@ class TimeConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -145,27 +146,26 @@ class TimeConstraintSpec extends RESTSpec{
      *  when: "I query observations in this study with startDate after 01-01-2016 and an endDate before 01-04-2016"
      *  then: "4 observations are returned"
      */
-    @Requires({EHR_LOADED})
-    def "query observations based on starDate and endDate"(){
+    def "query observations based on starDate and endDate"() {
         given: "EHR is loaded"
         def date1 = toDateString("01-01-2016Z")
         def date2 = toDateString("04-04-2016Z")
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: toQuery([
-                        type: Combination,
+                query     : toQuery([
+                        type    : Combination,
                         operator: AND,
-                        args: [
+                        args    : [
                                 [type: StudyNameConstraint, studyId: EHR_ID],
-                                [type: TimeConstraint,
-                                 field: [dimension: 'start time', fieldName: 'startDate', type: 'DATE' ],
+                                [type    : TimeConstraint,
+                                 field   : [dimension: 'start time', fieldName: 'startDate', type: 'DATE'],
                                  operator: AFTER,
-                                 values: date1],
-                                [type: TimeConstraint,
-                                 field: [dimension: 'end time', fieldName: 'endDate', type: 'DATE' ],
+                                 values  : date1],
+                                [type    : TimeConstraint,
+                                 field   : [dimension: 'end time', fieldName: 'endDate', type: 'DATE'],
                                  operator: BEFORE,
-                                 values: date2]
+                                 values  : date2]
                         ]
                 ])
         ]
@@ -182,8 +182,8 @@ class TimeConstraintSpec extends RESTSpec{
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/TranscriptLevelRnaSeqSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/TranscriptLevelRnaSeqSpec.groovy
@@ -1,10 +1,12 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.hypercube
 
+import annotations.RequiresStudy
 import base.RESTSpec
 import groovy.json.JsonBuilder
-import selectors.ObservationSelector
 
+import static base.ContentTypeFor.contentTypeForJSON
+import static base.ContentTypeFor.contentTypeForProtobuf
 import static config.Config.PATH_OBSERVATIONS
 import static config.Config.RNASEQ_TRANSCRIPT_ID
 import static tests.rest.v2.constraints.*
@@ -14,6 +16,7 @@ import static tests.rest.v2.constraints.*
  *  TMPREQ-13 Retrieving transcript level RNA-Seq data via the REST API
  *  TMPREQ-15 Retrieving data filtered by proteins, transcripts, and genes using standard ontologies via the API
  */
+@RequiresStudy(RNASEQ_TRANSCRIPT_ID)
 class TranscriptLevelRnaSeqSpec extends RESTSpec {
 
     /**
@@ -23,11 +26,11 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
      */
     def "transcripts link to genes"() {
         def requestTranscript = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
-                        constraint    : new JsonBuilder([
+                query     : [
+                        type                : 'autodetect',
+                        constraint          : new JsonBuilder([
                                 type: ConceptConstraint,
                                 path: '\\Public Studies\\RNASEQ_TRANSCRIPT\\HD\\Lung\\'
                         ]),
@@ -42,11 +45,11 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
         ]
 
         def requestGene = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
-                        constraint    : new JsonBuilder([
+                query     : [
+                        type                : 'autodetect',
+                        constraint          : new JsonBuilder([
                                 type: ConceptConstraint,
                                 path: '\\Public Studies\\RNASEQ_TRANSCRIPT\\HD\\Lung\\'
                         ]),
@@ -68,13 +71,13 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
         def expectedCellCount = 78
         assert responseData1.cells.size() == expectedCellCount
         assert responseData2.cells.size() == expectedCellCount
-        responseData1.cells.eachWithIndex{ cell, i ->
+        responseData1.cells.eachWithIndex { cell, i ->
             assert cell == responseData2.cells[i]
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -85,11 +88,11 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
      */
     def "transcripts link to different sets"() {
         def request1 = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
-                        constraint    : new JsonBuilder([
+                query     : [
+                        type                : 'autodetect',
+                        constraint          : new JsonBuilder([
                                 type: ConceptConstraint,
                                 path: '\\Public Studies\\RNASEQ_TRANSCRIPT\\HD\\Lung\\'
                         ]),
@@ -104,11 +107,11 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
         ]
 
         def request2 = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
-                        constraint    : new JsonBuilder([
+                query     : [
+                        type                : 'autodetect',
+                        constraint          : new JsonBuilder([
                                 type: ConceptConstraint,
                                 path: '\\Public Studies\\RNASEQ_TRANSCRIPT\\HD\\Lung\\'
                         ]),
@@ -133,8 +136,8 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
         assert responseData1 != responseData2
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -145,11 +148,11 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
      */
     def "transcripts do not accept gene names"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
-                        constraint    : new JsonBuilder([
+                query     : [
+                        type                : 'autodetect',
+                        constraint          : new JsonBuilder([
                                 type: ConceptConstraint,
                                 path: '\\Public Studies\\RNASEQ_TRANSCRIPT\\HD\\Lung\\'
                         ]),
@@ -173,8 +176,8 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
         assert responseData.type == 'InvalidArgumentsException'
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -185,11 +188,11 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
      */
     def "list of transcripts"() {
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
-                        constraint    : new JsonBuilder([
+                query     : [
+                        type                : 'autodetect',
+                        constraint          : new JsonBuilder([
                                 type: ConceptConstraint,
                                 path: '\\Public Studies\\RNASEQ_TRANSCRIPT\\HD\\Lung\\'
                         ]),
@@ -204,11 +207,11 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
         ]
 
         def requestAssayOnly = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
-                        constraint    : new JsonBuilder([
+                query     : [
+                        type      : 'autodetect',
+                        constraint: new JsonBuilder([
                                 type: ConceptConstraint,
                                 path: '\\Public Studies\\RNASEQ_TRANSCRIPT\\HD\\Lung\\'
                         ])
@@ -225,8 +228,8 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
         assert responseData1 != responseData2
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 
@@ -246,13 +249,13 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
                 -4.3447292229,
                 -4.347572611,
                 -4.3470865035
-                ]
+        ]
         def request = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
-                        constraint    : new JsonBuilder([
+                query     : [
+                        type                : 'autodetect',
+                        constraint          : new JsonBuilder([
                                 type: ConceptConstraint,
                                 path: '\\Public Studies\\RNASEQ_TRANSCRIPT\\HD\\Lung\\'
                         ]),
@@ -263,7 +266,7 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
                                         names: ['tr1']
                                 ]
                         ]),
-                        projection: 'zscore'
+                        projection          : 'zscore'
                 ]
         ]
 
@@ -286,11 +289,10 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
-
 
     /**
      *  given: "study RNASEQ_TRANSCRIPT is loaded"
@@ -299,20 +301,20 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
      */
     def "Link to multi transcript"() {
         def requestGene = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
-                        constraint    : new JsonBuilder([
-                                "type": Combination,
+                query     : [
+                        type                : 'autodetect',
+                        constraint          : new JsonBuilder([
+                                "type"    : Combination,
                                 "operator": "and",
-                                "args": [
+                                "args"    : [
                                         [
                                                 type: ConceptConstraint,
                                                 path: '\\Public Studies\\RNASEQ_TRANSCRIPT\\HD\\Lung\\'
                                         ],
                                         [
-                                                "type": StudyNameConstraint,
+                                                "type"   : StudyNameConstraint,
                                                 "studyId": "RNASEQ_TRANSCRIPT"
                                         ]
                                 ]
@@ -328,20 +330,20 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
         ]
 
         def requestTranscript = [
-                path: PATH_OBSERVATIONS,
+                path      : PATH_OBSERVATIONS,
                 acceptType: acceptType,
-                query: [
-                        type: 'autodetect',
-                        constraint    : new JsonBuilder([
-                                "type": "combination",
+                query     : [
+                        type                : 'autodetect',
+                        constraint          : new JsonBuilder([
+                                "type"    : "combination",
                                 "operator": "and",
-                                "args": [
+                                "args"    : [
                                         [
                                                 type: ConceptConstraint,
                                                 path: '\\Public Studies\\RNASEQ_TRANSCRIPT\\HD\\Lung\\'
                                         ],
                                         [
-                                                "type": StudyNameConstraint,
+                                                "type"   : StudyNameConstraint,
                                                 "studyId": "RNASEQ_TRANSCRIPT"
                                         ]
                                 ]
@@ -364,13 +366,13 @@ class TranscriptLevelRnaSeqSpec extends RESTSpec {
         def expectedCellCount = 156
         assert responseData1.cells.size() == expectedCellCount
         assert responseData2.cells.size() == expectedCellCount
-        responseData1.cells.eachWithIndex{ cell, i ->
+        responseData1.cells.eachWithIndex { cell, i ->
             assert cell == responseData2.cells[i]
         }
 
         where:
-        acceptType | newSelector
-        contentTypeForJSON | jsonSelector
+        acceptType             | newSelector
+        contentTypeForJSON     | jsonSelector
         contentTypeForProtobuf | protobufSelector
     }
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/storage/ArvadosWorkflowsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/storage/ArvadosWorkflowsSpec.groovy
@@ -3,19 +3,20 @@ package tests.rest.v2.storage
 
 import base.RESTSpec
 
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.*
 
 /**
  *  Creating ArvadosWorkflows
  *  TMPREQ-31 Starting an Arvados workflow from tranSMART API.
  */
-class ArvadosWorkflowsSpec extends RESTSpec{
+class ArvadosWorkflowsSpec extends RESTSpec {
 
 
     def setup() {
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def responseDataAll = get([path: PATH_ARVADOS_WORKFLOWS, acceptType: contentTypeForJSON])
-        responseDataAll.supportedWorkflows.each{
+        responseDataAll.supportedWorkflows.each {
             delete([path: PATH_ARVADOS_WORKFLOWS + "/${it.id}", acceptType: contentTypeForJSON, statusCode: 204])
         }
     }
@@ -23,24 +24,24 @@ class ArvadosWorkflowsSpec extends RESTSpec{
     /**
      *  post, get, put, delete
      */
-    def "post, get, put, delete"(){
+    def "post, get, put, delete"() {
         given:
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
-        def data = ["uuid":"bla",
-                    "arvadosInstanceUrl":"a",
-                    "name":"name",
-                    "description":"sc",
-                    "arvadosVersion":"v1",
-                    "defaultParams": [
-                            "a":1, "b":"b"
+        def data = ["uuid"              : "bla",
+                    "arvadosInstanceUrl": "a",
+                    "name"              : "name",
+                    "description"       : "sc",
+                    "arvadosVersion"    : "v1",
+                    "defaultParams"     : [
+                            "a": 1, "b": "b"
                     ],
         ]
 
         when:
         def responseData = post([
-                path: PATH_ARVADOS_WORKFLOWS,
+                path      : PATH_ARVADOS_WORKFLOWS,
                 acceptType: contentTypeForJSON,
-                body: toJSON(data),
+                body      : toJSON(data),
                 statusCode: 201
         ])
         def id = responseData.id
@@ -101,14 +102,14 @@ class ArvadosWorkflowsSpec extends RESTSpec{
         given:
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def request = [
-                path: PATH_ARVADOS_WORKFLOWS,
+                path      : PATH_ARVADOS_WORKFLOWS,
                 acceptType: contentTypeForJSON,
-                body: toJSON(["uuid": null,
-                              "arvadosInstanceUrl": null,
-                              "name": null,
-                              "description": null,
-                              "arvadosVersion": null,
-                              "defaultParams": null
+                body      : toJSON(["uuid"              : null,
+                                    "arvadosInstanceUrl": null,
+                                    "name"              : null,
+                                    "description"       : null,
+                                    "arvadosVersion"    : null,
+                                    "defaultParams"     : null
                 ]),
                 statusCode: 500
         ]
@@ -132,9 +133,9 @@ class ArvadosWorkflowsSpec extends RESTSpec{
 
         when:
         def responseData = post([
-                path: PATH_ARVADOS_WORKFLOWS,
+                path      : PATH_ARVADOS_WORKFLOWS,
                 acceptType: contentTypeForJSON,
-                body: null,
+                body      : null,
                 statusCode: 500
         ])
 
@@ -153,7 +154,7 @@ class ArvadosWorkflowsSpec extends RESTSpec{
 
         when:
         def responseData = get([
-                path: PATH_ARVADOS_WORKFLOWS + "/0",
+                path      : PATH_ARVADOS_WORKFLOWS + "/0",
                 acceptType: contentTypeForJSON,
                 statusCode: 404
         ])
@@ -171,19 +172,19 @@ class ArvadosWorkflowsSpec extends RESTSpec{
     def "put invalid"() {
         given:
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
-        def data = ["uuid":"bla",
-                    "arvadosInstanceUrl":"a",
-                    "name":"name",
-                    "description":"sc",
-                    "arvadosVersion":"v1",
-                    "defaultParams": [
-                            "a":1, "b":"b"
+        def data = ["uuid"              : "bla",
+                    "arvadosInstanceUrl": "a",
+                    "name"              : "name",
+                    "description"       : "sc",
+                    "arvadosVersion"    : "v1",
+                    "defaultParams"     : [
+                            "a": 1, "b": "b"
                     ],
         ]
         def responseData = post([
-                path: PATH_ARVADOS_WORKFLOWS,
+                path      : PATH_ARVADOS_WORKFLOWS,
                 acceptType: contentTypeForJSON,
-                body: toJSON(data),
+                body      : toJSON(data),
                 statusCode: 201
 
         ])
@@ -191,8 +192,8 @@ class ArvadosWorkflowsSpec extends RESTSpec{
 
         when:
         responseData = put([
-                path: PATH_ARVADOS_WORKFLOWS +"/${responseData.id}",
-                body: toJSON(data),
+                path      : PATH_ARVADOS_WORKFLOWS + "/${responseData.id}",
+                body      : toJSON(data),
                 statusCode: 422
         ])
 
@@ -210,21 +211,21 @@ class ArvadosWorkflowsSpec extends RESTSpec{
     def "put nonexistent"() {
         given:
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
-        def data = ["uuid":"bla",
-                    "arvadosInstanceUrl":"a",
-                    "name":"name",
-                    "description":"sc",
-                    "arvadosVersion":"v1",
-                    "defaultParams": [
-                            "a":1, "b":"b"
+        def data = ["uuid"              : "bla",
+                    "arvadosInstanceUrl": "a",
+                    "name"              : "name",
+                    "description"       : "sc",
+                    "arvadosVersion"    : "v1",
+                    "defaultParams"     : [
+                            "a": 1, "b": "b"
                     ],
         ]
 
         when:
         def responseData = put([
-                path: PATH_ARVADOS_WORKFLOWS +"/0",
+                path      : PATH_ARVADOS_WORKFLOWS + "/0",
                 acceptType: contentTypeForJSON,
-                body: toJSON(data),
+                body      : toJSON(data),
                 statusCode: 404
         ])
 
@@ -238,24 +239,24 @@ class ArvadosWorkflowsSpec extends RESTSpec{
     /**
      *  no access
      */
-    def "no access"(){
+    def "no access"() {
         given:
         setUser(DEFAULT_USERNAME, DEFAULT_PASSWORD)
-        def data = ["uuid":"bla",
-                    "arvadosInstanceUrl":"a",
-                    "name":"name",
-                    "description":"sc",
-                    "arvadosVersion":"v1",
-                    "defaultParams": [
-                            "a":1, "b":"b"
+        def data = ["uuid"              : "bla",
+                    "arvadosInstanceUrl": "a",
+                    "name"              : "name",
+                    "description"       : "sc",
+                    "arvadosVersion"    : "v1",
+                    "defaultParams"     : [
+                            "a": 1, "b": "b"
                     ],
         ]
 
         when:
         def responseData = post([
-                path: PATH_ARVADOS_WORKFLOWS,
+                path      : PATH_ARVADOS_WORKFLOWS,
                 acceptType: contentTypeForJSON,
-                body: toJSON(data),
+                body      : toJSON(data),
                 statusCode: 403
         ])
 
@@ -267,9 +268,9 @@ class ArvadosWorkflowsSpec extends RESTSpec{
         when:
         data.name = 'new file Link renamed'
         responseData = put([
-                path: PATH_ARVADOS_WORKFLOWS + "/0",
+                path      : PATH_ARVADOS_WORKFLOWS + "/0",
                 acceptType: contentTypeForJSON,
-                body: toJSON(data),
+                body      : toJSON(data),
                 statusCode: 403
         ])
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/storage/FileAccessSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/storage/FileAccessSpec.groovy
@@ -1,33 +1,36 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.storage
 
+import annotations.RequiresStudy
 import base.RESTSpec
 
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.*
 
+@RequiresStudy(SHARED_CONCEPTS_RESTRICTED_ID)
 class FileAccessSpec extends RESTSpec {
 
     def storageId
     def file_link
 
-    def setup(){
+    def setup() {
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def responseDataAll = get([path: PATH_FILES, acceptType: contentTypeForJSON])
-        responseDataAll.files.each{
+        responseDataAll.files.each {
             delete([path: PATH_FILES + "/${it.id}", statusCode: 204])
         }
 
         responseDataAll = get([path: PATH_STORAGE, acceptType: contentTypeForJSON])
-        responseDataAll.storageSystems.each{
+        responseDataAll.storageSystems.each {
             delete([path: PATH_STORAGE + "/${it.id}", statusCode: 204])
         }
 
         def sourceSystem = [
-                'name':'Arvbox at The Hyve',
-                'systemType':'Arvados',
-                'url':'http://arvbox-pro-dev.thehyve.net/',
-                'systemVersion':'v1',
-                'singleFileCollections':false,
+                'name'                 : 'Arvbox at The Hyve',
+                'systemType'           : 'Arvados',
+                'url'                  : 'http://arvbox-pro-dev.thehyve.net/',
+                'systemVersion'        : 'v1',
+                'singleFileCollections': false,
         ]
         def responseData = post([path: PATH_STORAGE, body: toJSON(sourceSystem), statusCode: 201])
         storageId = responseData.id
@@ -46,13 +49,13 @@ class FileAccessSpec extends RESTSpec {
      *  when: "I get files for that study"
      *  then: "I get an access error"
      */
-    def "get files by study"(){
+    def "get files by study"() {
         given: "a file is attached to a restricted study and I do not have access"
         setUser(DEFAULT_USERNAME, DEFAULT_PASSWORD)
 
         when: "I get files for that study"
         def responseData = get([
-                path: PATH_STUDIES+"/${SHARED_CONCEPTS_RESTRICTED_ID}/files",
+                path      : PATH_STUDIES + "/${SHARED_CONCEPTS_RESTRICTED_ID}/files",
                 acceptType: contentTypeForJSON,
                 statusCode: 403
         ])
@@ -67,13 +70,13 @@ class FileAccessSpec extends RESTSpec {
      *  when: "I get files for that study"
      *  then: "I get a list of files"
      */
-    def "get files by study unrestricted"(){
+    def "get files by study unrestricted"() {
         given: "a file is attached to a restricted study and I have access"
         setUser(UNRESTRICTED_USERNAME, UNRESTRICTED_PASSWORD)
 
         when: "I get files for that study"
         def responseData = get([
-                path: PATH_STUDIES+"/${SHARED_CONCEPTS_RESTRICTED_ID}/files",
+                path      : PATH_STUDIES + "/${SHARED_CONCEPTS_RESTRICTED_ID}/files",
                 acceptType: contentTypeForJSON,
         ])
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/storage/FilesSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/storage/FilesSpec.groovy
@@ -1,37 +1,40 @@
 /* Copyright © 2017 The Hyve B.V. */
 package tests.rest.v2.storage
 
+import annotations.RequiresStudy
 import base.RESTSpec
 
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.*
 
 /**
  *  external file links
  *  TMPREQ-19 Support linking to external data in Arvados from tranSMART API
  */
-class FilesSpec extends RESTSpec{
+@RequiresStudy(EHR_ID)
+class FilesSpec extends RESTSpec {
 
-
+    def studyId = EHR_ID
     def storageId
 
-    def setup(){
+    def setup() {
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def responseDataAll = get([path: PATH_FILES, acceptType: contentTypeForJSON])
-        responseDataAll.files.each{
+        responseDataAll.files.each {
             delete([path: PATH_FILES + "/${it.id}", statusCode: 204])
         }
 
         responseDataAll = get([path: PATH_STORAGE, acceptType: contentTypeForJSON])
-        responseDataAll.storageSystems.each{
+        responseDataAll.storageSystems.each {
             delete([path: PATH_STORAGE + "/${it.id}", statusCode: 204])
         }
 
         def sourceSystem = [
-                'name':'Arvbox at The Hyve',
-                'systemType':'Arvados',
-                'url':'http://arvbox-pro-dev.thehyve.net/',
-                'systemVersion':'v1',
-                'singleFileCollections':false,
+                'name'                 : 'Arvbox at The Hyve',
+                'systemType'           : 'Arvados',
+                'url'                  : 'http://arvbox-pro-dev.thehyve.net/',
+                'systemVersion'        : 'v1',
+                'singleFileCollections': false,
         ]
         def responseData = post([path: PATH_STORAGE, body: sourceSystem, statusCode: 201])
         storageId = responseData.id
@@ -40,12 +43,12 @@ class FilesSpec extends RESTSpec{
     /**
      *  post, get, put, delete
      */
-    def "post, get, put, delete"(){
+    def "post, get, put, delete"() {
         given:
         def new_file_link = [
                 'name'        : 'new file Link',
                 'sourceSystem': storageId,
-                'study'       : 'EHR',
+                'study'       : studyId,
                 'uuid'        : 'aaaaa-bbbbb-ccccccccccccccc',
         ]
 
@@ -57,7 +60,7 @@ class FilesSpec extends RESTSpec{
         assert responseData.id != null
         assert responseData.name == 'new file Link'
         assert responseData.sourceSystem == storageId
-        assert responseData.study == 'EHR'
+        assert responseData.study == studyId
         assert responseData.uuid == 'aaaaa-bbbbb-ccccccccccccccc'
 
         when:
@@ -67,7 +70,7 @@ class FilesSpec extends RESTSpec{
         assert responseData.id == id
         assert responseData.name == 'new file Link'
         assert responseData.sourceSystem == storageId
-        assert responseData.study == 'EHR'
+        assert responseData.study == studyId
         assert responseData.uuid == 'aaaaa-bbbbb-ccccccccccccccc'
 
         when:
@@ -84,7 +87,7 @@ class FilesSpec extends RESTSpec{
         assert responseData.id == id
         assert responseData.name == 'new file Link renamed'
         assert responseData.sourceSystem == storageId
-        assert responseData.study == 'EHR'
+        assert responseData.study == studyId
         assert responseData.uuid == 'aaaaa-bbbbb-ccccccccccccccc'
 
         when:
@@ -107,25 +110,25 @@ class FilesSpec extends RESTSpec{
     def "post and get from multiple storage systems"() {
         given: "There are multiple storage systems with file links"
         def sourceSystem = [
-                'name':'Arvbox at The Hyve 2',
-                'systemType':'Arvados',
-                'url':'http://arvbox-pro-dev.thehyve.net/',
-                'systemVersion':'v1',
-                'singleFileCollections':false,
+                'name'                 : 'Arvbox at The Hyve 2',
+                'systemType'           : 'Arvados',
+                'url'                  : 'http://arvbox-pro-dev.thehyve.net/',
+                'systemVersion'        : 'v1',
+                'singleFileCollections': false,
         ]
         def storageId2 = post([path: PATH_STORAGE, body: sourceSystem, statusCode: 201]).id
 
         def new_file_link1 = [
                 'name'        : 'file in storage 1',
                 'sourceSystem': storageId,
-                'study'       : 'EHR',
+                'study'       : studyId,
                 'uuid'        : 'bbbbb-ccccccccccccccc',
         ]
 
         def new_file_link2 = [
                 'name'        : 'file in storage 2',
                 'sourceSystem': storageId2,
-                'study'       : 'EHR',
+                'study'       : studyId,
                 'uuid'        : 'aaaaa-ccccccccccccccc',
         ]
 
@@ -174,7 +177,7 @@ class FilesSpec extends RESTSpec{
 
         then:
         assert responseData.errors.size() == 4
-        responseData.errors.each {['sourceSystem', 'study', 'name', 'uuid'].contains(it.field)}
+        responseData.errors.each { ['sourceSystem', 'study', 'name', 'uuid'].contains(it.field) }
     }
 
     /**
@@ -199,7 +202,7 @@ class FilesSpec extends RESTSpec{
         def new_file_link = [
                 'name'        : 'new file Link',
                 'sourceSystem': storageId,
-                'study'       : 'EHR',
+                'study'       : studyId,
                 'uuid'        : 'aaaaa-bbbbb-ccccccccccccccc',
         ]
         def responseData = post([path: PATH_FILES, body: toJSON(new_file_link), statusCode: 201])
@@ -208,8 +211,8 @@ class FilesSpec extends RESTSpec{
 
         when:
         responseData = put([
-                path: (PATH_FILES +"/${id}"),
-                body: toJSON(new_file_link),
+                path      : (PATH_FILES + "/${id}"),
+                body      : toJSON(new_file_link),
                 statusCode: 422])
 
         then:
@@ -229,12 +232,12 @@ class FilesSpec extends RESTSpec{
         def new_file_link = [
                 'name'        : 'new file Link',
                 'sourceSystem': storageId,
-                'study'       : 'EHR',
+                'study'       : studyId,
                 'uuid'        : 'aaaaa-bbbbb-ccccccccccccccc',
         ]
 
         when:
-        def responseData = put([path: PATH_FILES +"/0", body: toJSON(new_file_link), statusCode: 500])
+        def responseData = put([path: PATH_FILES + "/0", body: toJSON(new_file_link), statusCode: 500])
 
         then:
         assert responseData.httpStatus == 500
@@ -247,13 +250,13 @@ class FilesSpec extends RESTSpec{
     /**
      *  no access
      */
-    def "no access"(){
+    def "no access"() {
         given:
         setUser(DEFAULT_USERNAME, DEFAULT_PASSWORD)
         def new_file_link = [
                 'name'        : 'new file Link',
                 'sourceSystem': storageId,
-                'study'       : 'EHR',
+                'study'       : studyId,
                 'uuid'        : 'aaaaa-bbbbb-ccccccccccccccc',
         ]
 

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/storage/StorageSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/storage/StorageSpec.groovy
@@ -3,23 +3,24 @@ package tests.rest.v2.storage
 
 import base.RESTSpec
 
+import static base.ContentTypeFor.contentTypeForJSON
 import static config.Config.*
 
 /**
  *  external storage
  *  TMPREQ-19 Support linking to external data in Arvados from tranSMART API
  */
-class StorageSpec extends RESTSpec{
+class StorageSpec extends RESTSpec {
 
     def setup() {
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def responseDataAll = get([path: PATH_FILES, acceptType: contentTypeForJSON])
-        responseDataAll.files.each{
+        responseDataAll.files.each {
             delete([path: PATH_FILES + "/${it.id}", statusCode: 204])
         }
 
         responseDataAll = get([path: PATH_STORAGE, acceptType: contentTypeForJSON])
-        responseDataAll.storageSystems.each{
+        responseDataAll.storageSystems.each {
             delete([path: PATH_STORAGE + "/${it.id}", statusCode: 204])
         }
     }
@@ -27,15 +28,15 @@ class StorageSpec extends RESTSpec{
     /**
      *  post, get, put, delete
      */
-    def "post, get, put, delete"(){
+    def "post, get, put, delete"() {
         given:
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def sourceSystem = [
-                'name':'Arvbox at The Hyve',
-                'systemType':'Arvados',
-                'url':'http://arvbox-pro-dev.thehyve.net/',
-                'systemVersion':'v1',
-                'singleFileCollections':false,
+                'name'                 : 'Arvbox at The Hyve',
+                'systemType'           : 'Arvados',
+                'url'                  : 'http://arvbox-pro-dev.thehyve.net/',
+                'systemVersion'        : 'v1',
+                'singleFileCollections': false,
         ]
 
         when:
@@ -93,14 +94,14 @@ class StorageSpec extends RESTSpec{
 
     /**
      *  post invalid
-    */
-    def"post missing values"(){
+     */
+    def "post missing values"() {
         given:
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def sourceSystem = [
-                'name':'post invalid',
-                'systemType':'Arvados',
-                'url':'http://arvbox-pro-dev.thehyve.net/',
+                'name'      : 'post invalid',
+                'systemType': 'Arvados',
+                'url'       : 'http://arvbox-pro-dev.thehyve.net/',
         ]
 
         when:
@@ -115,15 +116,15 @@ class StorageSpec extends RESTSpec{
     /**
      *  post invalid
      */
-    def "post invalid json format"(){
+    def "post invalid json format"() {
         given:
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def sourceSystem = toJSON([
-                'name':'Arvbox at The Hyve',
-                'systemType':'Arvados',
-                'url':'http://arvbox-pro-dev.thehyve.net/',
-                'systemVersion':'v1',
-                'singleFileCollections':false,
+                'name'                 : 'Arvbox at The Hyve',
+                'systemType'           : 'Arvados',
+                'url'                  : 'http://arvbox-pro-dev.thehyve.net/',
+                'systemVersion'        : 'v1',
+                'singleFileCollections': false,
         ])
         sourceSystem = sourceSystem.take(20)
 
@@ -137,15 +138,15 @@ class StorageSpec extends RESTSpec{
     /**
      *  post invalid
      */
-    def "post invalid value"(){
+    def "post invalid value"() {
         given:
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def sourceSystem = [
-                'name':'Arvbox at The Hyve',
-                'systemType':'Arvados',
-                'url':'http://arvbox-pro-dev.thehyve.net/',
-                'systemVersion':'v1',
-                'singleFileCollections':'bad_value',
+                'name'                 : 'Arvbox at The Hyve',
+                'systemType'           : 'Arvados',
+                'url'                  : 'http://arvbox-pro-dev.thehyve.net/',
+                'systemVersion'        : 'v1',
+                'singleFileCollections': 'bad_value',
         ]
 
         when:
@@ -161,7 +162,7 @@ class StorageSpec extends RESTSpec{
     /**
      *  post empty
      */
-    def "post invalid empty"(){
+    def "post invalid empty"() {
         given:
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
 
@@ -175,7 +176,7 @@ class StorageSpec extends RESTSpec{
     /**
      *  get invalid
      */
-    def "get invalid value"(){
+    def "get invalid value"() {
         when:
         def responseData = get([path: PATH_STORAGE + "/some_letters", acceptType: contentTypeForJSON, statusCode: 404])
 
@@ -188,7 +189,7 @@ class StorageSpec extends RESTSpec{
     /**
      *  get nonexistent
      */
-    def "get nonexistent"(){
+    def "get nonexistent"() {
         when:
         def responseData = get([path: PATH_STORAGE + "/0", acceptType: contentTypeForJSON, statusCode: 404])
 
@@ -201,15 +202,15 @@ class StorageSpec extends RESTSpec{
     /**
      *  put invalid
      */
-    def "put invalid values"(){
+    def "put invalid values"() {
         given:
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def sourceSystem = [
-                'name':'Arvbox at The Hyve',
-                'systemType':'Arvados',
-                'url':'http://arvbox-pro-dev.thehyve.net/',
-                'systemVersion':'v1',
-                'singleFileCollections':false,
+                'name'                 : 'Arvbox at The Hyve',
+                'systemType'           : 'Arvados',
+                'url'                  : 'http://arvbox-pro-dev.thehyve.net/',
+                'systemVersion'        : 'v1',
+                'singleFileCollections': false,
         ]
 
         when:
@@ -227,16 +228,16 @@ class StorageSpec extends RESTSpec{
     /**
      *  put nonexistent
      */
-    def "put nonexistent"(){
+    def "put nonexistent"() {
         given:
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def id = 0
         def sourceSystem = [
-                'name':'Arvbox at The Hyve',
-                'systemType':'Arvados',
-                'url':'http://arvbox-pro-dev.thehyve.net/',
-                'systemVersion':'v1',
-                'singleFileCollections':false,
+                'name'                 : 'Arvbox at The Hyve',
+                'systemType'           : 'Arvados',
+                'url'                  : 'http://arvbox-pro-dev.thehyve.net/',
+                'systemVersion'        : 'v1',
+                'singleFileCollections': false,
         ]
 
         when:
@@ -251,15 +252,15 @@ class StorageSpec extends RESTSpec{
     /**
      *  no access
      */
-    def "post no access"(){
+    def "post no access"() {
         given:
         setUser(DEFAULT_USERNAME, DEFAULT_PASSWORD)
         def sourceSystem = [
-                'name':'Arvbox at The Hyve',
-                'systemType':'Arvados',
-                'url':'http://arvbox-pro-dev.thehyve.net/',
-                'systemVersion':'v1',
-                'singleFileCollections':false,
+                'name'                 : 'Arvbox at The Hyve',
+                'systemType'           : 'Arvados',
+                'url'                  : 'http://arvbox-pro-dev.thehyve.net/',
+                'systemVersion'        : 'v1',
+                'singleFileCollections': false,
         ]
 
         when:
@@ -273,28 +274,27 @@ class StorageSpec extends RESTSpec{
     /**
      *  no access
      */
-    def "delete no access"(){
+    def "delete no access"() {
         given:
         setUser(ADMIN_USERNAME, ADMIN_PASSWORD)
         def sourceSystem = [
-                'name':'Arvbox at The Hyve',
-                'systemType':'Arvados',
-                'url':'http://arvbox-pro-dev.thehyve.net/',
-                'systemVersion':'v1',
-                'singleFileCollections':false,
+                'name'                 : 'Arvbox at The Hyve',
+                'systemType'           : 'Arvados',
+                'url'                  : 'http://arvbox-pro-dev.thehyve.net/',
+                'systemVersion'        : 'v1',
+                'singleFileCollections': false,
         ]
 
         when:
         def responseData = post([path: PATH_STORAGE, body: toJSON(sourceSystem), statusCode: 201])
         setUser(DEFAULT_USERNAME, DEFAULT_PASSWORD)
-        responseData = delete([ path: PATH_STORAGE + "/${responseData.id}", statusCode: 403])
+        responseData = delete([path: PATH_STORAGE + "/${responseData.id}", statusCode: 403])
 
         then:
         assert responseData.httpStatus == 403
         assert responseData.message == 'Removing a storage system entry is an admin action'
         assert responseData.type == 'AccessDeniedException'
     }
-
 
 
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/versions/VersionsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/versions/VersionsSpec.groovy
@@ -3,7 +3,9 @@ package tests.rest.versions
 
 import base.RESTSpec
 
-import static config.Config.*
+import static base.ContentTypeFor.contentTypeForJSON
+import static config.Config.NON_EXISTING_API_VERSION
+import static config.Config.VERSIONS_PATH
 
 class VersionsSpec extends RESTSpec {
 
@@ -39,7 +41,7 @@ class VersionsSpec extends RESTSpec {
     def "fetch non existing version"() {
         when: "I fetch version v0"
         def responseData = get([
-                path: "${VERSIONS_PATH}/${NON_EXISTING_API_VERSION}",
+                path      : "${VERSIONS_PATH}/${NON_EXISTING_API_VERSION}",
                 acceptType: contentTypeForJSON,
                 statusCode: 404
         ])


### PR DESCRIPTION
there are 2 changes in this PR
1. made the rest helper calls static and moved them to a different class
2. expanded the spock annotations with RequiresStudy. It takes a study name or list of names. at the start, it checks which studies are loaded on the targeted server. tests that need studies that are not loaded are ignored.